### PR TITLE
Update almost all npm deps and introduce webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ npm_debug.log
 *.bak
 dist/*.js
 dist/*.css
+dist/favicon.ico
+dist/*.map

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: dist
 
 build: dist_dir
-	./node_modules/.bin/browserify -t [ babelify ] ./scripts/index -o ./dist/bundle.js
+	./node_modules/.bin/webpack
 
 less: dist_dir
 	./node_modules/.bin/lessc ./styles/main.less > ./dist/style.css
@@ -13,6 +13,9 @@ uglify:
 	cat ./dist/bundle.js | ./node_modules/.bin/uglifyjs --compress -o ./dist/bundle.min.js
 	du -ha ./dist/bundle.js
 	du -ha ./dist/bundle.min.js
+
+watch: dist_dir
+	./node_modules/.bin/webpack -w
 
 clean:
 	rm -rf dist

--- a/package.json
+++ b/package.json
@@ -2,46 +2,46 @@
   "name": "drone-ui",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/drone/drone-ui.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache",
   "bugs": {
     "url": "https://github.com/drone/drone-ui/issues"
   },
   "homepage": "https://github.com/drone/drone-ui",
   "dependencies": {
     "babel-polyfill": "^6.0.2",
-    "history": "^1.9.0",
+    "history": "^2.0.0",
     "isomorphic-fetch": "^2.2.0",
-    "lodash": "^3.10.1",
+    "lodash": "^4.3.0",
     "moment": "^2.10.6",
     "react": "^0.14.2",
     "react-dom": "^0.14.2",
     "react-modal": "^0.6.1",
     "react-redux": "^4.0.0",
-    "react-router": "1.0.0-rc3",
-    "react-stickynode": "^0.1.1",
+    "react-router": "^2.0.0",
+    "react-stickynode": "^1.0.6",
     "redux": "^3.0.4",
-    "redux-router": "1.0.0-beta3",
+    "redux-router": "^1.0.0-beta7",
     "redux-thunk": "^1.0.0"
   },
   "devDependencies": {
-    "babel": "5.8.3",
+    "babel": "^6.5.1",
     "babel-cli": "^6.1.1",
-    "babel-core": "^6.0.20",
-    "babel-loader": "^6.0.1",
+    "babel-core": "^6.5.1",
+    "babel-loader": "^6.2.2",
     "babel-plugin-transform-react-jsx": "^6.0.18",
-    "babelify": "6.1.3",
-    "browserify": "11.0.0",
-    "less": "2.5.1",
-    "redux-devtools": "^2.1.5",
-    "rollup-plugin-babel": "^1.0.0",
-    "uglify-js": "2.4.24",
-    "webpack": "^1.12.2"
+    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-react": "^6.5.0",
+    "babelify": "^7.2.0",
+    "less": "^2.6.0",
+    "redux-devtools": "^3.1.1",
+    "rollup-plugin-babel": "^2.3.9",
+    "uglify-js": "^2.6.1",
+    "webpack": "^1.12.13"
   },
   "jest": {
     "testFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -37,9 +37,13 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "babelify": "^7.2.0",
+    "css-loader": "^0.23.1",
+    "extract-text-webpack-plugin": "^1.0.1",
     "less": "^2.6.0",
+    "less-loader": "^2.2.2",
     "redux-devtools": "^3.1.1",
     "rollup-plugin-babel": "^2.3.9",
+    "style-loader": "^0.13.0",
     "uglify-js": "^2.6.1",
     "webpack": "^1.12.13"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/drone/drone-ui.git"
   },
   "author": "",
-  "license": "Apache",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/drone/drone-ui/issues"
   },

--- a/scripts/containers/App.js
+++ b/scripts/containers/App.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import { connect } from "react-redux";
-import { pushState } from "redux-router";
+import { push } from "redux-router";
 import Header from "../components/header";
 import HeaderGuest from "../components/header_guest";
 
@@ -10,12 +10,13 @@ class App extends Component {
   }
 
   handleChange(nextValue) {
-    this.props.pushState(null, `/${nextValue}`)
+    this.props.push(null, `/${nextValue}`)
   }
 
   render() {
-    const { content, pagehead, pagenav } = this.props.children;
-    
+    const { content, pagehead, pagenav } = this.props;
+    //const { content, pagehead, pagenav } = this.props.children;
+
     var header;
     if (this.props.user) {
       header = <Header user={this.props.user} />;
@@ -42,9 +43,9 @@ function mapStateToProps(state) {
 
 App.props = {
   children: PropTypes.node,
-  pushState: PropTypes.func.isRequired,
+  push: PropTypes.func.isRequired,
 }
 
 export default connect(mapStateToProps, {
-  pushState,
+  push,
 })(App);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,29 +1,47 @@
-var path = require('path');
+var webpack = require('webpack');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 module.exports = {
-  entry: './scripts/index.js',
-  devtool: 'source-map',
+  entry: [
+    './src/index.js'
+  ],
   output: {
-    filename: './dist/bundle.js'
+    filename: 'bundle.js',
+    path: './dist'
   },
-  module: {
-    loaders: [
-      {
-        test: /\.js?$/,
-        exclude: /(node_modules|bower_components)/,
-        loader: 'babel',
-        query: {
-          presets: ['react', 'es2015']
-        }
-      }
-    ]
-  },
+  devtool: 'source-map',
   externals: {
     'react': 'React',
     'react-dom': 'ReactDOM',
     'moment': 'moment'
   },
   resolve: {
-    extensions: ['', '.js', '.jsx']
-  }
+    extensions: ['', '.js']
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.(js|jsx)/,
+        loader: 'babel',
+        query: {presets: ['react', 'es2015']},
+        exclude: /node_modules/
+      },
+      {
+        test: /\.css/,
+        loader: ExtractTextPlugin.extract("style-loader", "css-loader")
+      },
+      {
+        test: /\.less$/,
+        loader: ExtractTextPlugin.extract("style-loader", "css-loader!less-loader")
+      }
+    ]
+  },
+  plugins: [
+    new ExtractTextPlugin('style.css'),
+    new webpack.DefinePlugin({
+      'process.env': {
+        'NODE_ENV': "'production'"
+      }
+    })
+  ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,29 @@
+var path = require('path');
+
+module.exports = {
+  entry: './scripts/index.js',
+  devtool: 'source-map',
+  output: {
+    filename: './dist/bundle.js'
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js?$/,
+        exclude: /(node_modules|bower_components)/,
+        loader: 'babel',
+        query: {
+          presets: ['react', 'es2015']
+        }
+      }
+    ]
+  },
+  externals: {
+    'react': 'React',
+    'react-dom': 'ReactDOM',
+    'moment': 'moment'
+  },
+  resolve: {
+    extensions: ['', '.js', '.jsx']
+  }
+};


### PR DESCRIPTION
Webpack is awesome for developing with react.
There's a `webpack -w` command which I've introduced as `make watch`.
It caches all modules and only recompiles the ones, that changed.
Building after changing a react component now takes ms instead of 5s.