### PR TITLE
Make --scheme optional in proxy server.

### DIFF
--- a/server.go
+++ b/server.go
@@ -23,6 +23,12 @@ var (
 func main() {
 	flag.Parse()
 
+	hostScheme := strings.Split(*host, "://")
+	if len(hostScheme) == 2 {
+		*scheme = hostScheme[0]
+		*host = hostScheme[1]
+	}
+
 	// create the drone client and get the Drone user
 	client := drone.NewClientToken(*scheme+"://"+*host, *token)
 	user, err := client.Self()


### PR DESCRIPTION
This is just a simple addition to the proxyserver that makes it possible
to omit the `--scheme` flag and instead parse the scheme from the
`--host` parameter. The old behaviour still works.

(I also sneaked in a commit correcting the build instruction in the README)