### PR TITLE
Serve all assets and prefix them with hashes

### DIFF
--- a/index.html.ejs
+++ b/index.html.ejs
@@ -4,11 +4,13 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1" name="viewport"/>
   <meta content="ie=edge" http-equiv="x-ua-compatible"/>
+  <link href="/static/favicon.ico" rel="icon" type="image/x-icon"/>
   <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
-  <link href="/static/app.css" rel="stylesheet"/>
-  <link href="/static/favicon.ico" rel="icon" type="image/x-icon"/>
+  <% for (var i = 0; i < htmlWebpackPlugin.files.css.length; i++) { %>
+  <link href="<%= htmlWebpackPlugin.files.css[i] %>" rel="stylesheet"/>
+  <% } %>
 </head>
 <body>
 <div id="app"></div>
@@ -16,6 +18,8 @@
   window.STATE_FROM_SERVER = {}
 </script>
 <script src="https://code.getmdl.io/1.1.3/material.min.js"></script>
-<script src="/static/app.js"></script>
+<% for (var i = 0; i < htmlWebpackPlugin.files.js.length; i++) { %>
+<script src="<%= htmlWebpackPlugin.files.js[i] %>"></script>
+<% } %>
 </body>
 </html>

--- a/index.html.ejs
+++ b/index.html.ejs
@@ -5,9 +5,6 @@
   <meta content="width=device-width, initial-scale=1" name="viewport"/>
   <meta content="ie=edge" http-equiv="x-ua-compatible"/>
   <link href="/static/favicon.ico" rel="icon" type="image/x-icon"/>
-  <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet"/>
-  <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet"/>
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
   <% for (var i = 0; i < htmlWebpackPlugin.files.css.length; i++) { %>
   <link href="<%= htmlWebpackPlugin.files.css[i] %>" rel="stylesheet"/>
   <% } %>
@@ -17,7 +14,6 @@
 <script>
   window.STATE_FROM_SERVER = {}
 </script>
-<script src="https://code.getmdl.io/1.1.3/material.min.js"></script>
 <% for (var i = 0; i < htmlWebpackPlugin.files.js.length; i++) { %>
 <script src="<%= htmlWebpackPlugin.files.js[i] %>"></script>
 <% } %>

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-react": "^4.2.3",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
+    "html-webpack-plugin": "^2.22.0",
     "less": "^2.6.1",
     "less-loader": "^2.2.3",
     "webpack": "^1.12.14",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,15 @@
     "baobab-react": "2.1.1",
     "emmett": "^3.1.1",
     "lodash.debounce": "^4.0.6",
+    "material-design-icons": "^2.2.3",
+    "material-design-lite": "^1.1.3",
     "moment": "^2.12.0",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
     "react-mdl": "^1.5.3",
     "react-router": "^2.0.1",
+    "roboto-fontface": "^0.5.0",
+    "roboto-mono-webfont": "^2.0.986",
     "superagent": "^1.8.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ import {routes} from './routes';
 import {tree} from './actions/tree';
 import {events} from './actions/events';
 
+import 'material-design-lite';
+
 // Creating our top-level component
 class App extends React.Component {
   render() {

--- a/src/index.less
+++ b/src/index.less
@@ -1,4 +1,10 @@
-@import "../node_modules/react-mdl/extra/material.min.css";
+@import "~roboto-fontface/css/roboto/less/roboto-fontface";
+@roboto-font-path: '~roboto-fontface/fonts';
+@import (less) "~roboto-mono-webfont/roboto-mono.css";
+
+@import "~react-mdl/extra/material.css";
+@import (less) "~material-design-icons/iconfont/material-icons.css";
+
 @import "variables";
 @import "mixins";
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,18 +1,18 @@
 /* eslint-env node */
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
 var path = require('path');
 var webpack = require('webpack');
 
 module.exports = {
   entry: {
     app: [
-      './index.html',
       './src/index.js'
     ]
   },
   output: {
-    filename: 'static/app.js',
+    filename: 'static/app-[hash].js',
     path: path.resolve(__dirname, 'dist'),
     publicPath: '/'
   },
@@ -51,10 +51,18 @@ module.exports = {
     extensions: ['', '.js', '.jsx']
   },
   plugins: [
-    new ExtractTextPlugin('static/app.css'),
+    new ExtractTextPlugin('static/app-[hash].css'),
     new CopyWebpackPlugin([
         { from: 'images', to: 'static' }
     ]),
+    new HtmlWebpackPlugin({
+      template: './index.html.ejs',
+      inject: false,
+      minify: {
+        collapseWhitespace: true,
+        minifyCSS: true
+      }
+    }),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
     })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,10 @@ module.exports = {
         )
       },
       {
+        test: /\/(fonts|iconfont)\/(.*)\.(eot|svg|ttf|woff2?)(\?.*)?$/,
+        loader: 'file?name=static/[name]-[hash].[ext]'
+      },
+      {
         test: /index\.html$/,
         loader: 'file?name=[name].[ext]'
       }


### PR DESCRIPTION
This PR incorporates all external assets and serves them directly. Additionally all assets are prefixed with hashes.

This allows to set long term cache headers for the whole `static/` folder (`drone.svg` and `favicon.ico` are yet the only exceptions from that rule).

Why serving all assets directly and not from CDN? I suggest that many will run their CI in corporate environments. IMHO having the plus in privacy by not needing to request content from third parties outweights the small chance, to already have a certain file somewhere in cache. And even if not, since all assets have hashes and so can be long term cached, this is at most a concern for the very first visit of the UI.