### PR TITLE
Add Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:argon
+
+# Create app directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install app dependencies
+COPY package.json /usr/src/app/
+RUN npm install
+
+
+# Bundle app source
+COPY . /usr/src/app
+
+EXPOSE 9000
+ENTRYPOINT [ "npm", "start" ]


### PR DESCRIPTION
 Simple docker file on `node:argon` base image (node 4.4.7 version). Tested against drone `v0.5`. 