### PR TITLE
Provide different color for icon of pending jobs

### DIFF
--- a/src/components/status.less
+++ b/src/components/status.less
@@ -38,10 +38,16 @@
   &.pending, &.running {
     color: #FFA000;
     border-color: #FFA000;
-    &:before {
-      content: "refresh";
-      animation: spinner 1.2s ease infinite;
-    }
+  }
+
+  &.pending:before {
+    content: "alarm";
+    animation: wrench 2.5s ease infinite;
+  }
+
+  &.running:before {
+    content: "refresh";
+    animation: spinner 1.2s ease infinite;
   }
 
   &.unknown {
@@ -52,4 +58,26 @@
 @keyframes spinner {
   0%{transform:rotate(0deg)}
   100%{transform:rotate(359deg)}
+}
+
+/**
+ * keyframes for wrench animation are from font-awesome-animation
+ * https://github.com/l-lin/font-awesome-animation
+ **/
+@keyframes wrench {
+	0%{transform:rotate(-12deg)}
+	8%{transform:rotate(12deg)}
+	10%{transform:rotate(24deg)}
+	18%{transform:rotate(-24deg)}
+	20%{transform:rotate(-24deg)}
+	28%{transform:rotate(24deg)}
+	30%{transform:rotate(24deg)}
+	38%{transform:rotate(-24deg)}
+	40%{transform:rotate(-24deg)}
+	48%{transform:rotate(24deg)}
+	50%{transform:rotate(24deg)}
+	58%{transform:rotate(-24deg)}
+	60%{transform:rotate(-24deg)}
+	68%{transform:rotate(24deg)}
+	75%,100%{transform:rotate(0deg)}
 }


### PR DESCRIPTION
This then looks like this:

<img width="312" alt="bildschirmfoto 2016-09-09 um 16 48 46" src="https://cloud.githubusercontent.com/assets/245432/18391152/4f965f72-76ad-11e6-94b6-10a31b472709.png">

Before both icons for pending and running had the same color.