### PR TITLE
Support Firefox 49 by using react-router provided location

### DIFF
--- a/src/actions/tree.js
+++ b/src/actions/tree.js
@@ -3,22 +3,11 @@ import Baobab from 'baobab';
 // loads the user from the server state.
 const user = window.STATE_FROM_SERVER && window.STATE_FROM_SERVER.user;
 
-// loads the window location from the browser.
-const location = window && window.location ? {
-  href: window.location.href,
-  origin: window.location.origin,
-  pathname: window.location.pathname
-} : {};
-
 // tree stores the global state of the application.
 export const tree = new Baobab({
   // the user branch of the tree maintains the currently authenticated user
   // information, sourced from the STATE_FROM_SERVER global variable.
   user: user,
-
-  // the location branch of the tree maintains the browser location, sourced
-  // from the window.location global variable.
-  location: location,
 
   // the repos branch of the tree maintains an index of repository nodes
   // organized by repository owner and repository name. For example:

--- a/src/pages/repository/toolbar.js
+++ b/src/pages/repository/toolbar.js
@@ -33,6 +33,5 @@ class Toolbar extends React.Component {
 
 
 export default branch({
-  user: ['user'],
-  location: ['location']
+  user: ['user']
 }, Toolbar);


### PR DESCRIPTION
This restores active toolbar tab highlighting which was disabled in 9b40b6986db7fc986f0d9c1b3aa9adea7e423164, by using `this.props.location` injected by react-router instead of browser `window.location`.