### PR TITLE
Use a Better CDN for MDL

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <script>
   window.STATE_FROM_SERVER = {}
 </script>
-<script src="https://code.getmdl.io/1.1.3/material.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.1.3/material.min.js"></script>
 <script src="/static/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR uses a better and faster public CDN for `material-design-lite` library (`cdnjs` powered by cloudflare)
Also in some countries such as Iran google restricted access to it's hosted repos !! So UI is completely unusable...
~~Also this upgrades mdl version from `1.1.3` to latest `1.2.1` :)~~
