### PR TITLE
Open details for build by default to make following easier

### DIFF
--- a/src/pages/build/results.js
+++ b/src/pages/build/results.js
@@ -130,7 +130,7 @@ export class Results extends React.Component {
     return (
       <PageContent fluid className="build">
         <BuildPanel repo={repo} build={build} job={job}>
-          <details>
+          <details open>
             <summary></summary>
             <div>
               {job.status == RUNNING ? <Button ripple onClick={this.handleCancel}>cancel</Button> : <noscript />}


### PR DESCRIPTION
As discussed on gitter before, it's tedious to show the two buttons by clicking the bottom on the right. Instead show both buttons by default and make them hideable.

<img width="659" alt="screen shot 2016-12-27 at 20 49 48" src="https://cloud.githubusercontent.com/assets/872251/21507129/0e6020fa-cc76-11e6-9dbc-84c95260e31a.png">
