### PR TITLE
Keep aspect ratio of Drone logo

### DIFF
--- a/src/components/layout/page.js
+++ b/src/components/layout/page.js
@@ -41,7 +41,7 @@ class Page extends React.Component {
               <Drawer>
                 <div className="brand">
                   <Link to="/">
-                      <Avatar className="logo" src="/static/drone.svg"/>
+                      <img className="logo" src="/static/drone.svg"/>
                   </Link>
                 </div>
                 <Navigation>

--- a/src/components/layout/page.less
+++ b/src/components/layout/page.less
@@ -88,7 +88,7 @@
 
   a {
     display:inline-block;
-    margin-top: 10px;
+    margin-top: 16px;
     margin-left: 15px;
   }
 }


### PR DESCRIPTION
The Drone logo isn't an avatar (isn't square). I've increased the top margin so that this matches the avatar margin on the right.

Before:
![before](https://cloud.githubusercontent.com/assets/80071/22420292/19753238-e6e2-11e6-883e-8a3a1cf1b544.png)

After:
![after](https://cloud.githubusercontent.com/assets/80071/22420297/1e7591f6-e6e2-11e6-8149-09265f0b13dc.png)