### PR TITLE
Center tab label in clickable area

### DIFF
--- a/src/components/layout/tabs.less
+++ b/src/components/layout/tabs.less
@@ -2,7 +2,7 @@
 
 .tabs {
   margin: 0;
-  padding: 0px 40px;
+  padding: 0px 30px;
   border-bottom: 1px solid #eee;
   list-style: none;
 
@@ -13,7 +13,7 @@
   a {
     display: inline-block;
     line-height: 49px;
-    padding-right: 20px;
+    padding: 0px 10px;
     text-decoration: none;
     color: #212121;
     font-size: 15px;


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/80071/22423118/4307adfc-e6f0-11e6-8b1c-bc1e047be9ff.png)

After:
![after](https://cloud.githubusercontent.com/assets/80071/22423120/4472b9de-e6f0-11e6-9d64-eaa82235c2c7.png)