### PR TITLE
Center slider thumb button in Firefox

### DIFF
--- a/src/pages/repository_settings/index.less
+++ b/src/pages/repository_settings/index.less
@@ -47,6 +47,11 @@
   height:10px;
   border-radius: 5px;
 }
+@-moz-document url-prefix() {
+  .mdl-slider__background-flex {
+    margin-top: -3px;
+  }
+}
 .mdl-slider__background-lower {
   background: #00BFA5;
 }


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/80071/22500165/0ba6a04c-e863-11e6-987c-532ed938d30b.png)

After:
![after](https://cloud.githubusercontent.com/assets/80071/22500167/0f336470-e863-11e6-882f-eb4b44277af7.png)

Matches the appearance in Chrome now :)