### PR TITLE
Show ellipsis for long repo names

### DIFF
--- a/src/components/repo_list_item.less
+++ b/src/components/repo_list_item.less
@@ -14,6 +14,10 @@
 
   span {
     text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 225px;
+    display: inline-block;
   }
 
   .status {


### PR DESCRIPTION
Very long repository names without characters like `-` won't word-break and therefore make the horizontal scroll-bar appear (and move the status icon down). After this PR `...` will be used to shorten the name in these cases.

## Before
![before](https://cloud.githubusercontent.com/assets/80071/24451344/bafca09a-147e-11e7-952c-f0eea8af3630.png)

## After
![after](https://cloud.githubusercontent.com/assets/80071/24451350/bfefdb58-147e-11e7-9aab-9afe8f8b7826.png)
