### PR TITLE
Don't use repo variable before it is available

### DIFF
--- a/src/actions/events.js
+++ b/src/actions/events.js
@@ -384,7 +384,7 @@ events.on(POST_REPO, (event) => {
     .end((err, response) => {
       if (err != null) {
         console.error(err);
-        tree.set(['pages', 'toast'], `Error activating ${repo.full_name}`);
+        tree.set(['pages', 'toast'], `Error activating ${owner}/${name}`);
         return;
       }
 
@@ -402,7 +402,7 @@ events.on(POST_REPO, (event) => {
         }
       });
 
-      // append the repsotiroy to the feed.
+      // append the repository to the feed.
       tree.push(['feed'], repo);
       tree.set(['pages', 'toast'], `Successfully activated ${repo.full_name}`);
     });


### PR DESCRIPTION
The repo variable isn't available until https://github.com/jhasse/drone-ui/blob/4cb3de77305d8240e19ef644fd3951176aacd706/src/actions/events.js#L391

This fixes error messages not showing up when activating a repository in the account settings.