### PR TITLE
fix rendering of matrix builds with parents (fork builds)

### DIFF
--- a/src/pages/build/matrix.js
+++ b/src/pages/build/matrix.js
@@ -19,7 +19,7 @@ export class Matrix extends React.Component {
 
     return (
       <PageContent fluid className="build">
-        <BuildPanel build={build} job={build} />
+        <BuildPanel repo={repo} build={build} job={build} />
         <div>
           {build.procs && build.procs.map(renderProc)}
         </div>


### PR DESCRIPTION
`BuildPanel` component is not being passed the `repo` props on matrix builds. This breaks the rending of matrix builds that are "forked" (i.e. has a parent).

Passing the props downstream fixes this bug.