### PR TITLE
Allow output lines with long words to be broken

### DIFF
--- a/src/components/term_row.less
+++ b/src/components/term_row.less
@@ -20,6 +20,7 @@
 
   &> div:nth-child(2) {
     flex: 1 1 auto;
+    min-width: 0;
   }
 
   &> div:last-child {


### PR DESCRIPTION
When there's a long string of characters without spaces in the build log, it falls off the edge of the page. Setting min-width to 0, per [this article](https://hackernoon.com/11-things-i-learned-reading-the-flexbox-spec-5f0c799c776b), allows these long strings to be wrapped.

Before:
![image](https://cloud.githubusercontent.com/assets/2947280/26757219/8c7aecfa-48ad-11e7-9e8f-e6700ae12547.png)

After:
![image](https://cloud.githubusercontent.com/assets/2947280/26757221/95f3e9a8-48ad-11e7-8b4b-ce3c0b8e71b5.png)
