### PR TITLE
(css) Fix .term-row styling issue

### DIFF
--- a/src/drone/drone-proc.html
+++ b/src/drone/drone-proc.html
@@ -46,8 +46,6 @@
 			color: #212121;
 			font-size: 12px;
 			line-height: 19px;
-			white-space: pre-wrap;
-			word-wrap: break-word;
 			font-family: Roboto Mono,monospace;
 			display: flex;
 			max-width:100%;
@@ -62,6 +60,8 @@
 		.term-row>div:nth-child(2) {
 			flex: 1 1 auto;
 			min-width: 0;
+			white-space: pre-wrap;
+			word-wrap: break-word;
 		}
 		.term-row>div:last-child {
 			padding-left: 20px;


### PR DESCRIPTION
Fixes https://github.com/drone/drone-ui/issues/132

So, this is *one* version of the fix. There is an alternative, which is arguably less desirable. The jist of the alternative solution is the following:

Change
```
<div class="term-row">
  <div></div>
  <div></div>
  <div></div>
</div>
```
to
```
<div class="term-row"><div></div><div></div><div></div></div>
```

This alternative solution also hints at the problem (at least in Safari, maybe others?). HTML code formatting is counted when the parent has ```white-space: nowrap``` in Safari (luckily Chrome seems to understand how to handle this as expected). New lines and multiple spaces are honored, both of which can and do exist in the HTML output inside ```.term-row``` elements and messes with the flex layout.

This change moves the formatting rule  from the parent container to target specifically the div that contains actual log output where formatting via white-space is useful.

Thanks @jmccann for helping with troubleshooting.