### PR TITLE
Proposed 'pending' icon wiggle fix

### DIFF
--- a/src/drone/drone-status.html
+++ b/src/drone/drone-status.html
@@ -27,6 +27,7 @@
 			}
 			:host iron-icon.pending {
 				animation: wrench 2.5s ease infinite;
+				transform-origin: center 54%;
 			}
 			:host iron-icon.declined,
 			:host iron-icon.error,


### PR DESCRIPTION
By offsetting the centre of rotation, the "wiggle" effect of the animation is mitigated.

I cannot be sure whether it is intentional that the wiggle effect is there however it has always annoyed me slightly.
If you'd rather leave it as is, for nostalgia sake or whatever, I can understand that.

Below is an example of before and after, zoomed in at 400% in Chromium v60. At 100% zoom it is much smoother and less 'wiggly'

![animation before and after](https://i.imgur.com/ChzusZA.gif)