### PR TITLE
Add props that's needed in "deployment" build

### DIFF
--- a/src/shared/components/build_event.js
+++ b/src/shared/components/build_event.js
@@ -11,7 +11,7 @@ import styles from "./build_event.less";
 
 export default class BuildEvent extends Component {
 	render() {
-		const { event, branch, commit, refs, refspec, link } = this.props;
+		const { event, branch, commit, refs, refspec, link, target } = this.props;
 
 		return (
 			<div className={styles.host}>


### PR DESCRIPTION
When there are deployment build `target` is missing