### PR TITLE
Truncate long branch name

### DIFF
--- a/src/screens/feed/components/list.less
+++ b/src/screens/feed/components/list.less
@@ -1,3 +1,5 @@
+@import "~shared/styles/utils.less";
+
 .list {
 	a {
 		display:block;
@@ -27,10 +29,8 @@
 		color: #222;
 		flex: 1 1 auto;
 		max-width:250px;
-		overflow: hidden;
-			padding-right: 20px;
-			text-overflow: ellipsis;
-			white-space: nowrap;
+		padding-right: 20px;
+		.text-ellipsis
 	}
 
 	.body div time {

--- a/src/shared/components/build_event.less
+++ b/src/shared/components/build_event.less
@@ -1,3 +1,5 @@
+@import "~shared/styles/utils.less";
+
 .host {
 	position:relative;
 
@@ -27,5 +29,6 @@
 		flex: 1;
 		line-height: 24px;
 		font-size: 14px;
+		.text-ellipsis
 	}
 }

--- a/src/shared/styles/utils.less
+++ b/src/shared/styles/utils.less
@@ -1,0 +1,5 @@
+.text-ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}


### PR DESCRIPTION
Current interface, when branch name is long (eg using `feature/1234-implements-come-really-nice-feature-when-outside-the-window-rain`) generate inconsistency in UI, eg. in build list create row with different length in each build.

This PR ellipses text when branch name is too long to have consistency in visualization, if branch have "short" name full name is visibile, if branch name is too long it will truncate and text ellipsed. On my monitor branch with ~20 chars are fully visible, other are truncated.

## Before

<img width="1133" alt="screen shot 2017-09-10 at 15 23 34" src="https://user-images.githubusercontent.com/43941/30249401-16316682-963c-11e7-9ad7-897efc452cc3.png">

## After

<img width="1133" alt="screen shot 2017-09-10 at 15 21 19" src="https://user-images.githubusercontent.com/43941/30249402-1c2c8828-963c-11e7-8bd4-0f6224f7762e.png">
