### PR TITLE
Switch black and white since ansi_up assumes a dark terminal

### DIFF
--- a/src/screens/repo/screens/build/logs/components/term.less
+++ b/src/screens/repo/screens/build/logs/components/term.less
@@ -76,39 +76,35 @@
 // ansi terminal color and background settings
 // DO NOT EDIT
 :global {
-	.ansi-black-fg { color: #151515; }
-	.ansi-red-fg { color: #fb9fb1; }
-	.ansi-green-fg { color: #acc267; }
-	.ansi-yellow-fg { color: #ddb26f;}
-	.ansi-blue-fg { color: #6fc2ef; }
-	.ansi-magenta-fg { color: #e1a3ee;}
-	.ansi-cyan-fg { color: #12cfc0; }
-	.ansi-white-fg { color: #d0d0d0; }
+	.ansi-bright-black-fg,   .ansi-black-fg   { color: #B3B3B3; }
+	.ansi-bright-red-fg,     .ansi-red-fg     { color: #fb9fb1; }
+	.ansi-bright-green-fg,   .ansi-green-fg   { color: #acc267; }
+	.ansi-bright-yellow-fg,  .ansi-yellow-fg  { color: #ddb26f; }
+	.ansi-bright-blue-fg,    .ansi-blue-fg    { color: #6fc2ef; }
+	.ansi-bright-magenta-fg, .ansi-magenta-fg { color: #e1a3ee; }
+	.ansi-bright-cyan-fg,    .ansi-cyan-fg    { color: #12cfc0; }
+	.ansi-bright-white-fg,   .ansi-white-fg   { color: #151515; }
 
-	.ansi-bright-black-fg { color: #505050; }
-	.ansi-bright-red-fg { color: #fb9fb1; }
-	.ansi-bright-green-fg {color: #acc267;}
-	.ansi-bright-yellow-fg {color: #ddb26f;}
-	.ansi-bright-blue-fg {color: #6fc2ef;}
-	.ansi-bright-magenta-fg {color: #e1a3ee;}
-	.ansi-bright-cyan-fg {color: #12cfc0; }
-	.ansi-bright-white-fg { color: #f5f5f5; }
+	.ansi-bright-black-fg, .ansi-bright-red-fg, .ansi-bright-green-fg, .ansi-bright-yellow-fg,
+	.ansi-bright-blue-fg, .ansi-bright-magenta-fg, .ansi-bright-cyan-fg, .ansi-bright-white-fg {
+		font-weight: bold;
+	}
 
-	.ansi-black-bg { background-color: #151515; }
+	.ansi-black-bg { background-color: #d0d0d0; }
 	.ansi-red-bg { background-color: #fb9fb1; }
 	.ansi-green-bg { background-color: #acc267; }
 	.ansi-yellow-bg { background-color: #ddb26f;}
 	.ansi-blue-bg { background-color: #6fc2ef; }
 	.ansi-magenta-bg { background-color: #e1a3ee;}
 	.ansi-cyan-bg { background-color: #12cfc0; }
-	.ansi-white-bg { background-color: #d0d0d0; }
+	.ansi-white-bg { background-color: #151515; }
 
-	.ansi-bright-black-bg { background-color: #505050; }
+	.ansi-bright-black-bg { background-color: #f5f5f5; }
 	.ansi-bright-red-bg { background-color: #fb9fb1; }
 	.ansi-bright-green-bg {background-color: #acc267;}
 	.ansi-bright-yellow-bg {background-color: #ddb26f;}
 	.ansi-bright-blue-bg {background-color: #6fc2ef;}
 	.ansi-bright-magenta-bg {background-color: #e1a3ee;}
 	.ansi-bright-cyan-bg {background-color: #12cfc0; }
-	.ansi-bright-white-bg { background-color: #f5f5f5; }
+	.ansi-bright-white-bg { background-color: #505050; }
 }


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/80071/30366121-516f30d2-986a-11e7-904d-b76bf32dd436.png)

After:
![after](https://user-images.githubusercontent.com/80071/30366136-5cda6c16-986a-11e7-86e9-676c0e14bbab.png)

I think that ansi_up assumes a black terminal background and that's why it assigns a white color for "bold/bright". This results in compiler messages to be unreadable (see screenshot above).

I've swapped black and white and turned "bright" into bold. It isn't 100% correct (assigning the bold attribute shouldn't change the color), but this is the easiest fix without fixing ansi_up (which has other bugs too).

If you want I can also try to do #86 again.