### PR TITLE
fix background color for disabled button in sidebar menu

### DIFF
--- a/src/shared/components/drawer/drawer.less
+++ b/src/shared/components/drawer/drawer.less
@@ -136,7 +136,7 @@
       color: @gray;
       cursor:wait;
       &:hover {
-        background: @gray;
+        background: @gray-light;
       }
       svg {
         fill:@gray;


### PR DESCRIPTION
In sidebar menu (eg in repositories page) when there are disabled button on mouse-hover the menu the background color is the same we have on text and we should not read content; his fix will change background color to make possible read button content, eg:

Current (no mouse hover):

<img width="318" alt="repositories___drone" src="https://user-images.githubusercontent.com/43941/30524072-fd6c63fc-9bec-11e7-8c16-6d6e01864174.png">

Current (with mouse hover):

<img width="375" alt="repositories___drone" src="https://user-images.githubusercontent.com/43941/30524050-9fed7a22-9bec-11e7-95b9-5f049b652fcd.png">

Fix (with mouse hover):

<img width="350" alt="repositories___drone" src="https://user-images.githubusercontent.com/43941/30524064-e52662e8-9bec-11e7-9602-c4947d8d70e6.png">
