### PR TITLE
Also specifiy font weights for Roboto Mono, fix #74

### DIFF
--- a/src/screens/drone.less
+++ b/src/screens/drone.less
@@ -1,5 +1,5 @@
 :global {
-	@import url('https://fonts.googleapis.com/css?family=Roboto+Mono|Roboto:300,400,500');
+	@import url('https://fonts.googleapis.com/css?family=Roboto+Mono:400,700|Roboto:300,400,500');
 
 	* {
 		font-family: "Roboto";


### PR DESCRIPTION
Otherwise bold characters won't have the same width as normal characters in Firefox.