### PR TITLE
Mobile mode fixes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
 	<!-- drone:version -->
 	<!-- drone:user -->
 	<!-- drone:csrf -->

--- a/src/screens/layout.less
+++ b/src/screens/layout.less
@@ -49,9 +49,22 @@
 	width: 300px;
 }
 
+@media (max-width: 600px) {
+	.left {
+		display: none;
+	}
+}
+
 .center {
 	box-sizing: border-box;
 	padding-left: 300px;
+}
+
+@media (max-width: 600px) {
+	.center {
+		box-sizing: border-box;
+		padding-left: 0px;
+	}
 }
 
 .login {

--- a/src/screens/repo/screens/build/components/matrix.less
+++ b/src/screens/repo/screens/build/components/matrix.less
@@ -29,7 +29,7 @@
 
 .item {
 	display: flex;
-	flex-direction: row;
+	flex-flow: row wrap;
 }
 
 .header {
@@ -44,7 +44,7 @@
 
 .body {
 	border-left: 1px solid @gray-light;
-	flex: 0 0 200px;
+	flex: 0 1 200px;
 	padding-left: 20px;
 }
 

--- a/src/screens/repo/screens/build/index.less
+++ b/src/screens/repo/screens/build/index.less
@@ -11,7 +11,7 @@
 
 		.left {
 			box-sizing: border-box;
-			flex: 1 auto;
+			flex: 1 0;
 			min-width: 0px;
 			padding-right: 20px;
 			padding-top: 20px;
@@ -19,7 +19,7 @@
 
 		.right {
 			box-sizing: border-box;
-			flex: 1 1 350px;
+			flex: 0 1 350px;
 			min-width: 0px;
 			padding-right: 20px;
 			padding-top: 20px;

--- a/src/screens/repo/screens/build/index.less
+++ b/src/screens/repo/screens/build/index.less
@@ -7,10 +7,11 @@
 
 	.columns {
 		display: flex;
+		flex-flow: row wrap;
 
 		.left {
 			box-sizing: border-box;
-			flex: 1;
+			flex: 1 auto;
 			min-width: 0px;
 			padding-right: 20px;
 			padding-top: 20px;
@@ -18,7 +19,7 @@
 
 		.right {
 			box-sizing: border-box;
-			flex: 0 0 350px;
+			flex: 1 1 350px;
 			min-width: 0px;
 			padding-right: 20px;
 			padding-top: 20px;
@@ -48,4 +49,5 @@ section.sticky {
 	font-size: 14px;
 	margin-bottom: 10px;
 	padding: 20px;
+	word-wrap: break-word;
 }

--- a/src/screens/repo/screens/build/index.less
+++ b/src/screens/repo/screens/build/index.less
@@ -12,7 +12,7 @@
 		.left {
 			box-sizing: border-box;
 			flex: 1 0;
-			min-width: 0px;
+			min-width: 300px;
 			padding-right: 20px;
 			padding-top: 20px;
 		}

--- a/src/screens/repo/screens/builds/components/list.less
+++ b/src/screens/repo/screens/builds/components/list.less
@@ -54,6 +54,12 @@
 			padding: 0px;
 			padding-left: 52px;
 		}
+		
+		@media (max-width: 600px) {
+			.meta {
+				padding-left: 0px;
+			}
+		}
 
 		.time {
 			margin-top: 20px;


### PR DESCRIPTION
Little improvement to make mobile usable comparing to current state.
Tried not to break desktop mode, but minor layout change is possible.

1. Auto hide menu (currently it hides everything anyway)
2. Show everything vertically (flex-flow: row wrap)

Please let me know if I broke something.