### PR TITLE
Use type="password" for secret

### DIFF
--- a/src/screens/repo/screens/secrets/components/form.js
+++ b/src/screens/repo/screens/secrets/components/form.js
@@ -52,8 +52,8 @@ export class Form extends Component {
 					placeholder="Secret Name"
 					onChange={this._handleNameChange}
 				/>
-				<textarea
-					rows="1"
+				<input
+					type="password"
 					name="value"
 					value={this.state.value}
 					placeholder="Secret Value"


### PR DESCRIPTION
This prevents certain browser extensions (e.g. [Grammarly](https://chrome.google.com/webstore/detail/grammarly-for-chrome/kbfnbcaeplbcioakkpcpgfkobkghlhen?hl=en)) from parsing/reading the secret value pasted into the `password` field.