### PR TITLE
add promote build to build menu

### DIFF
--- a/src/screens/repo/screens/build/index.less
+++ b/src/screens/repo/screens/build/index.less
@@ -49,3 +49,12 @@ section.sticky {
 	margin-bottom: 10px;
 	padding: 20px;
 }
+section {
+	input {
+		border: 1px solid @gray-light;
+		font-size: 15px;
+		padding: 5px 10px;
+		margin-left: 10px;
+		width: 220px;
+	}
+}

--- a/src/screens/repo/screens/build/index.less
+++ b/src/screens/repo/screens/build/index.less
@@ -55,6 +55,5 @@ section {
 		font-size: 15px;
 		padding: 5px 10px;
 		margin-left: 10px;
-		width: 220px;
 	}
 }

--- a/src/screens/repo/screens/build/menu.js
+++ b/src/screens/repo/screens/build/menu.js
@@ -41,7 +41,7 @@ export default class BuildMenu extends Component {
 	getInitialState() {
 		return {
 			togglePromote: false,
-			customEnv: ''
+			customEnv: "",
 		};
 	}
 
@@ -51,7 +51,7 @@ export default class BuildMenu extends Component {
 	}
 
 	handlePromote(env) {
-		const {dispatch, drone, repo, build} = this.props;
+		const { dispatch, drone, repo, build } = this.props;
 		dispatch(promoteBuild, drone, repo.owner, repo.name, build.number, env);
 	}
 
@@ -89,10 +89,10 @@ export default class BuildMenu extends Component {
 		var handlePromote = this.handlePromote;
 		var envs = [];
 		if (build !== undefined && build.deploy_envs !== undefined) {
-			envs = build.deploy_envs.map(function (env) {
+			envs = build.deploy_envs.map(function(env) {
 				return env.name;
-			})
-		};
+			});
+		}
 
 		return (
 			<div>
@@ -116,24 +116,23 @@ export default class BuildMenu extends Component {
 								)}
 							</li>
 							<li>
-								{build.status === STATUS_SUCCESS  ? (
+								{build.status === STATUS_SUCCESS ? (
 									<button onClick={this.togglePromote}>
 										<DeployIcon />
 										<span>Promote Build</span>
 									</button>
-								):null }
-                                {build.status === STATUS_SUCCESS  && this.state.togglePromote ? (
-                                    <ul class="sub">{envs.map(function(env) {
-                                        return <li><button onClick={handlePromote.bind(this, env)}><PlayIcon /><span>{env}</span></button></li>
-                                    })}
-                                    <li><button onClick={handlePromote.bind(this, this.state.customEnv)}><PlayIcon/>
-                                        <input type="text" value={this.state.customEnv}
-                                               onClick={event => event.stopPropagation()}
-                                               onChange={this.updateCustomEnv.bind(this)}
-                                               placeholder="input and then click play icon">
-                                        </input>
-                                    </button></li>
-                                </ul>) :null }
+								) : null}
+								{build.status === STATUS_SUCCESS && this.state.togglePromote ? (
+									<ul className="sub">{envs.map(function(env) {
+										return <li><button onClick={handlePromote.bind(this, env)}><PlayIcon /><span>{env}</span></button></li>
+									})}
+									<li><button onClick={handlePromote.bind(this, this.state.customEnv)}><PlayIcon/>
+										<input type="text" value={this.state.customEnv}
+													onClick={event => event.stopPropagation()}
+													onChange={this.updateCustomEnv.bind(this)}
+													placeholder="Deployment target (eg: test)" />
+									</button></li>
+								</ul>) : null }
 							</li>
 						</ul>
 					</section>

--- a/src/screens/repo/screens/build/menu.js
+++ b/src/screens/repo/screens/build/menu.js
@@ -123,16 +123,33 @@ export default class BuildMenu extends Component {
 									</button>
 								) : null}
 								{build.status === STATUS_SUCCESS && this.state.togglePromote ? (
-									<ul className="sub">{envs.map(function(env) {
-										return <li><button onClick={handlePromote.bind(this, env)}><PlayIcon /><span>{env}</span></button></li>
-									})}
-									<li><button onClick={handlePromote.bind(this, this.state.customEnv)}><PlayIcon/>
-										<input type="text" value={this.state.customEnv}
+									<ul className="sub">
+										{envs.map(function(env, i) {
+											return (
+												<li key={i}>
+													<button onClick={handlePromote.bind(this, env)}>
+														<PlayIcon />
+														<span>{env}</span>
+													</button>
+												</li>
+											);
+										})}
+										<li>
+											<button
+												onClick={handlePromote.bind(this, this.state.customEnv)}
+											>
+												<PlayIcon />
+												<input
+													type="text"
+													value={this.state.customEnv}
 													onClick={event => event.stopPropagation()}
 													onChange={this.updateCustomEnv.bind(this)}
-													placeholder="Deployment target (eg: test)" />
-									</button></li>
-								</ul>) : null }
+													placeholder="Deployment target (eg: test)"
+												/>
+											</button>
+										</li>
+									</ul>
+								) : null}
 							</li>
 						</ul>
 					</section>

--- a/src/screens/repo/screens/build/menu.js
+++ b/src/screens/repo/screens/build/menu.js
@@ -14,6 +14,7 @@ import { repositorySlug } from "shared/utils/repository";
 import { branch } from "baobab-react/higher-order";
 import { inject } from "config/client/inject";
 import PlayIcon from "shared/components/icons/play";
+import { STATUS_SUCCESS } from "shared/constants/status";
 
 const binding = (props, context) => {
 	const { owner, repo, build } = props.match.params;
@@ -115,25 +116,25 @@ export default class BuildMenu extends Component {
 								)}
 							</li>
 							<li>
-								{build.status === "success" ? (
+								{build.status === STATUS_SUCCESS  ? (
 									<button onClick={this.togglePromote}>
 										<DeployIcon />
 										<span>Promote Build</span>
 									</button>
 								):null }
+                                {build.status === STATUS_SUCCESS  && this.state.togglePromote ? (
+                                    <ul class="sub">{envs.map(function(env) {
+                                        return <li><button onClick={handlePromote.bind(this, env)}><PlayIcon /><span>{env}</span></button></li>
+                                    })}
+                                    <li><button onClick={handlePromote.bind(this, this.state.customEnv)}><PlayIcon/>
+                                        <input type="text" value={this.state.customEnv}
+                                               onClick={event => event.stopPropagation()}
+                                               onChange={this.updateCustomEnv.bind(this)}
+                                               placeholder="input and then click play icon">
+                                        </input>
+                                    </button></li>
+                                </ul>) :null }
 							</li>
-							{build.status === "success" && this.state.togglePromote ? (
-								<ul class="sub">{envs.map(function(env) {
-									return <li><button onClick={handlePromote.bind(this, env)}><PlayIcon /><span>{env}</span></button></li>
-								})}
-								<li><button onClick={handlePromote.bind(this, this.state.customEnv)}><PlayIcon/>
-									<input type="text" value={this.state.customEnv}
-										   onClick={event => event.stopPropagation()}
-										   onChange={this.updateCustomEnv.bind(this)}
-										   placeholder="input and then click play icon">
-									</input>
-								</button></li>
-							</ul>) :null }
 						</ul>
 					</section>
 				)}

--- a/src/shared/components/drawer/drawer.less
+++ b/src/shared/components/drawer/drawer.less
@@ -103,13 +103,6 @@
 		padding: 0px 10px;
 	}
 
-	ul {
-		li {
-			margin: 0px;
-			padding: 0px;
-		}
-	}
-
 	a {
 		color: @gray-dark;
 		display: block;

--- a/src/shared/components/drawer/drawer.less
+++ b/src/shared/components/drawer/drawer.less
@@ -103,6 +103,13 @@
 		padding: 0px 10px;
 	}
 
+	ul {
+		li {
+			margin: 0px;
+			padding: 0px;
+		}
+	}
+
 	a {
 		color: @gray-dark;
 		display: block;

--- a/src/shared/utils/build.js
+++ b/src/shared/utils/build.js
@@ -116,6 +116,27 @@ export const restartBuild = (tree, client, owner, repo, build) => {
 };
 
 /**
+ * Promote build.
+ *
+ * @param {Object} tree - The drone state tree.
+ * @param {Object} client - The drone client.
+ * @param {string} owner - The repository owner.
+ * @param {string} name - The repository name.
+ * @param {number} build - The build number.
+ * @param {string} env - The environment deploy to.
+ */
+export const promoteBuild = (tree, client, owner, repo, build, env) => {
+	client
+		.restartBuild(owner, repo, build, { fork: true, event: "deployment", "deploy_to": env })
+		.then(result => {
+			displayMessage(tree, "Successfully promote your build");
+		})
+		.catch(() => {
+			displayMessage(tree, "Failed to promote your build");
+		});
+};
+
+/**
  * Approves the blocked build.
  *
  * @param {Object} tree - The drone state tree.

--- a/src/shared/utils/build.js
+++ b/src/shared/utils/build.js
@@ -127,7 +127,11 @@ export const restartBuild = (tree, client, owner, repo, build) => {
  */
 export const promoteBuild = (tree, client, owner, repo, build, env) => {
 	client
-		.restartBuild(owner, repo, build, { fork: true, event: "deployment", "deploy_to": env })
+		.restartBuild(owner, repo, build, {
+			fork: true,
+			event: "deployment",
+			deploy_to: env,
+		})
 		.then(result => {
 			displayMessage(tree, "Successfully promote your build");
 		})


### PR DESCRIPTION
Add a "Promote Build" menu to build drawer, when click it will toggle environments list display as follows. The deploy environment list is obtain from a modified droneServer api, see [this](https://github.com/drone/drone/pull/2332). Deploy parameters are not supported currently.
![image](https://user-images.githubusercontent.com/832911/35617812-180df126-06b4-11e8-8005-da0b4639499d.png)
