### PR TITLE
fixed non disappearing notifications

### DIFF
--- a/src/shared/utils/message.js
+++ b/src/shared/utils/message.js
@@ -1,11 +1,15 @@
 /**
- * Displays the globa message.
+ * Displays the global message.
  *
  * @param {Object} tree - The drone state tree.
  * @param {string} message - The message text.
  */
 export const displayMessage = (tree, message) => {
 	tree.set(["message", "text"], message);
+
+	setTimeout(() => {
+		hideMessage(tree);
+	}, 5000);
 };
 
 /**


### PR DESCRIPTION
Whenever a build is restarted or repositories are being synchronised, a little notification is shown at the bottom left but it refuses to go away and is stucked there till the page is refreshed. This PR makes sure it is only active for 5 seconds, afterwards the notification disappears. 