### PR TITLE
Allow to set events when adding new secret

### DIFF
--- a/src/screens/repo/screens/secrets/components/form.js
+++ b/src/screens/repo/screens/secrets/components/form.js
@@ -1,4 +1,12 @@
 import React, { Component } from "react";
+
+import {
+	EVENT_PUSH,
+	EVENT_TAG,
+	EVENT_PULL_REQUEST,
+	EVENT_DEPLOY,
+} from "shared/constants/events";
+
 import styles from "./form.less";
 
 export class Form extends Component {
@@ -8,10 +16,12 @@ export class Form extends Component {
 		this.state = {
 			name: "",
 			value: "",
+			event: [EVENT_PUSH, EVENT_TAG, EVENT_DEPLOY],
 		};
 
 		this._handleNameChange = this._handleNameChange.bind(this);
 		this._handleValueChange = this._handleValueChange.bind(this);
+		this._handleEventChange = this._handleEventChange.bind(this);
 		this._handleSubmit = this._handleSubmit.bind(this);
 
 		this.clear = this.clear.bind(this);
@@ -25,12 +35,27 @@ export class Form extends Component {
 		this.setState({ value: event.target.value });
 	}
 
+	_handleEventChange(event) {
+		const selected = this.state.event;
+		let index;
+
+		if (event.target.checked) {
+			selected.push(event.target.value);
+		} else {
+			index = selected.indexOf(event.target.value);
+			selected.splice(index, 1);
+		}
+
+		this.setState({ event: selected });
+	}
+
 	_handleSubmit() {
 		const { onsubmit } = this.props;
 
 		const detail = {
 			name: this.state.name,
 			value: this.state.value,
+			event: this.state.event,
 		};
 
 		onsubmit({ detail });
@@ -40,9 +65,15 @@ export class Form extends Component {
 	clear() {
 		this.setState({ name: "" });
 		this.setState({ value: "" });
+		this.setState({ event: [EVENT_PUSH, EVENT_TAG, EVENT_DEPLOY] });
 	}
 
 	render() {
+		let checked = this.state.event.reduce((map, event) => {
+			map[event] = true;
+			return map;
+		}, {});
+
 		return (
 			<div className={styles.form}>
 				<input
@@ -59,6 +90,47 @@ export class Form extends Component {
 					placeholder="Secret Value"
 					onChange={this._handleValueChange}
 				/>
+				<section>
+					<h2>Events</h2>
+					<div>
+						<label>
+							<input
+								type="checkbox"
+								checked={checked[EVENT_PUSH]}
+								value={EVENT_PUSH}
+								onChange={this._handleEventChange}
+							/>
+							<span>push</span>
+						</label>
+						<label>
+							<input
+								type="checkbox"
+								checked={checked[EVENT_TAG]}
+								value={EVENT_TAG}
+								onChange={this._handleEventChange}
+							/>
+							<span>tag</span>
+						</label>
+						<label>
+							<input
+								type="checkbox"
+								checked={checked[EVENT_PULL_REQUEST]}
+								value={EVENT_PULL_REQUEST}
+								onChange={this._handleEventChange}
+							/>
+							<span>pull request</span>
+						</label>
+						<label>
+							<input
+								type="checkbox"
+								checked={checked[EVENT_DEPLOY]}
+								value={EVENT_DEPLOY}
+								onChange={this._handleEventChange}
+							/>
+							<span>deploy</span>
+						</label>
+					</div>
+				</section>
 				<div className={styles.actions}>
 					<button onClick={this._handleSubmit}>Save</button>
 				</div>

--- a/src/screens/repo/screens/secrets/components/form.less
+++ b/src/screens/repo/screens/secrets/components/form.less
@@ -30,6 +30,62 @@
 		}
 	}
 
+	section {
+		display: flex;
+		flex: 1 1 auto;
+		padding-bottom: 20px;
+
+		&> div {
+			flex: 1;
+		}
+
+		&:first-child {
+			padding-top: 0px;
+		}
+
+		&:last-child {
+			border-bottom-width: 0px;
+		}
+
+		@media (max-width: 600px) {
+			display: flex;
+			flex-direction: column;
+
+			h2 {
+				flex: none;
+				margin-bottom: 20px;
+			}
+
+			&> :last-child {
+				padding-left: 20px;
+			}
+		}
+
+		h2 {
+			flex: 0 0 100px;
+			font-size: 15px;
+			font-weight: normal;
+			line-height: 26px;
+			margin: 0px;
+			padding: 0px;
+		}
+	
+		label {
+			display: block;
+			padding: 0px;
+	
+			span {
+				font-size: 15px;
+			}
+		}
+	
+		input[type='checkbox'] {
+			width: initial;
+			display: inline;
+			margin: 0px 10px 0px 0px;
+		}
+	}
+
 	.actions {
 		text-align: right;
 	}

--- a/src/screens/repo/screens/secrets/index.js
+++ b/src/screens/repo/screens/secrets/index.js
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 
 import { repositorySlug } from "shared/utils/repository";
-import { EVENT_PUSH, EVENT_TAG, EVENT_DEPLOY } from "shared/constants/events";
 import {
 	fetchSecretList,
 	createSecret,
@@ -48,7 +47,7 @@ export default class RepoSecrets extends Component {
 		const secret = {
 			name: e.detail.name,
 			value: e.detail.value,
-			event: [EVENT_PUSH, EVENT_TAG, EVENT_DEPLOY],
+			event: e.detail.event,
 		};
 
 		dispatch(createSecret, drone, owner, repo, secret);


### PR DESCRIPTION
Default is left as it was before when adding from UI

Screenshot:
![attels](https://user-images.githubusercontent.com/165205/38338854-fd4a1e68-3873-11e8-9c8e-5b994426d36f.png)
