### PR TITLE
Don't forcibly lowercase case-sensitive secret names

### DIFF
--- a/src/screens/repo/screens/secrets/components/list.less
+++ b/src/screens/repo/screens/secrets/components/list.less
@@ -18,7 +18,6 @@
 		flex: 1 1 auto;
 		font-size: 15px;
 		line-height: 32px;
-		text-transform: lowercase;
 	}
 
 	&> div:last-child {


### PR DESCRIPTION
Secret names when included in .drone.yml files are case sensitive. Lowercasing them in the UI leads to user confusion when the .yml file doesn't match the UI.