### PR TITLE
don't lowercase secret names in UI

### DIFF
--- a/src/screens/repo/screens/registry/components/list.less
+++ b/src/screens/repo/screens/registry/components/list.less
@@ -18,7 +18,6 @@
 		flex: 1 1 auto;
 		font-size: 15px;
 		line-height: 32px;
-		text-transform: lowercase;
 	}
 
 	&> div:last-child {


### PR DESCRIPTION
Variable names in most programming languages I use are case sensitive. When Drone UI presents names of secrets in lowercase using a CSS lowercase transform, I become scared that Drone has actually lowercased my desired variable name (which would be very cruel indeed), or whether Drone is simply presenting my desired variable name in lowercase (less cruel, but still pretty cruel).