### PR TITLE
Avoid truncated ANSI color codes in terminal output

### DIFF
--- a/src/screens/repo/screens/build/logs/components/term.js
+++ b/src/screens/repo/screens/build/logs/components/term.js
@@ -10,7 +10,7 @@ class Term extends Component {
 		const { lines, exitcode } = this.props;
 		return (
 			<div className={style.term}>
-				{lines.map(renderTermLine)}
+				{stitchLines(lines).map(renderTermLine)}
 				{exitcode !== undefined ? renderExitCode(exitcode) : undefined}
 			</div>
 		);
@@ -44,6 +44,30 @@ class TermLine extends Component {
 		return this.props.line.out !== nextProps.line.out;
 	}
 }
+
+const isEOL = line => {
+	return line.out.charAt(line.out.length - 1) === "\n";
+};
+
+const stitchLines = lines => {
+	return lines.reduce(
+		(stitchedLines, line) => {
+			let lastLine = stitchedLines[stitchedLines.length - 1];
+
+			if (isEOL(lastLine)) {
+				let newLine = Object.assign({}, line);
+				newLine.pos = stitchedLines.length + 1;
+
+				return stitchedLines.concat(newLine);
+			} else {
+				lastLine.out = lastLine.out.concat(line.out);
+
+				return stitchedLines;
+			}
+		},
+		[Object.assign({}, lines[0])],
+	);
+};
 
 const renderTermLine = line => {
 	return <TermLine line={line} />;


### PR DESCRIPTION
When fetched via the API, logs are split into lines with a position and timestamp. While this mostly occurs at newlines in the log output, there's also an upper length limit of 16k characters. Lines longer than this will be split on the 16k character boundary, regardless of whether a newline is present.

When dealing with color output, this has the potential to split in the middle of an ANSI color code. Because drone-ui formats each API log line separately, partial color codes can appear in plain text at the beginning and end of lines, and colors can fail to be reset correctly. Here's an example in the middle of a stream of green periods:

<img width="736" alt="20181217-9c4pn" src="https://user-images.githubusercontent.com/383376/50094770-de5c5680-020b-11e9-834b-fca68db34a6f.png">

This patch attempts to address the issue by stitching together log lines truncated in this manner. It works by inspecting the last character of the last log line seen, and appending the current line's log output unless the last line ended with a newline character.

Because log line objects are immutable, we have to clone the lines while stitching; we also need to update the line numbers to account for log lines that are joined together.

Any and all feedback is very welcome, but I'd be particularly interested in thoughts on:

1. Is this the right place to fix the issue? I considered the possibility of making the server avoid splitting lines in the middle of ANSI codes, but this seemed to introduce a whole new concern to the server code that it shouldn't need to worry about at all.
2. If so, is this sort of fix reasonable? There's a small loss of information in that we lose the timestamp for the partial "lines" that are now being stitched together. The display still updates as the current line grows, however, so visual progess isn't lost.
3. Can anyone think of any unintended consequences of this change that I haven't considered, e.g. on performance, or for uncolored output?

Thanks for taking a look!