### PR TITLE
Display build.title for build title

### DIFF
--- a/src/screens/repo/screens/build/components/details.js
+++ b/src/screens/repo/screens/build/components/details.js
@@ -14,7 +14,7 @@ export class Details extends Component {
 			<div className={styles.info}>
 				<StatusLabel status={build.status} />
 
-				<section className={styles.message}>{build.message}</section>
+				<section className={styles.message}>{build.title || build.message}</section>
 
 				<section>
 					<BuildTime

--- a/src/screens/repo/screens/builds/components/list.js
+++ b/src/screens/repo/screens/builds/components/list.js
@@ -21,7 +21,7 @@ export class Item extends Component {
 				</div>
 
 				<div className={styles.body}>
-					<h3>{build.message}</h3>
+					<h3>{build.title || build.message}</h3>
 				</div>
 
 				<div className={styles.meta}>


### PR DESCRIPTION
In Github (and perhaps others) PR builds the PR body/description is used as the title which makes for really long and not easily identifiable titles on the build list (especially with PR templates). This changes the build tiles to use `build.title || build.message`.  

*Problem:* 
<img width="242" alt="screen shot 2019-02-10 at 10 33 57" src="https://user-images.githubusercontent.com/1057902/52531534-829bde80-2d1f-11e9-8c0d-a7a811a508d5.png"> etc etc ...

I'm not fully aware of the repercussions for this change, but this will work for PR and push builds which don't have the title attribute. 