### PR TITLE
Preserve whitespace in build logs

### DIFF
--- a/src/views/Build.vue
+++ b/src/views/Build.vue
@@ -737,6 +737,7 @@ $output-header-sticky-offset: 20px;
 
 .ol-html {
   word-break: break-all;
+  white-space: pre-wrap;
   padding-right: 15px;
 }
 


### PR DESCRIPTION
Currently, consecutive spaces are collapsed inside the build logs, which messes up alignment using them. Adding `white-space: pre-wrap` to the style prevents this behavior.

Note that unlike `pre`, `pre-wrap` does not prevent the proper line wrapping from happening.

fixes #253 