### PR TITLE
Fix log download link in Firefox

### DIFF
--- a/src/views/Build.vue
+++ b/src/views/Build.vue
@@ -377,7 +377,9 @@ export default {
       link.download = `logs_${namespace}_${name}_${stage}_${step}.log`;
       link.href = URL.createObjectURL(blob);
       link.target = "_blank";
+      document.body.appendChild(link);
       link.click();
+      document.body.removeChild(link);
     },
     onScroll() {
       if (this.outputFullscreen) return;


### PR DESCRIPTION
This should fix an issue where Firefox users were unable to download job logs.

https://github.com/drone/drone-ui/issues/300