### PR TITLE
Truncate commit message to first line in RepoItem

### DIFF
--- a/src/components/RepoItem.vue
+++ b/src/components/RepoItem.vue
@@ -14,7 +14,7 @@
       <div class="header" :title="title">
         <span class="title">
           <span class="number" v-if="number">#{{ number }}. </span>
-          <span>{{ title }}</span>
+          <span>{{ title.split('\n')[0] }}</span>
         </span>
 
         <Button outline borderless


### PR DESCRIPTION
RepoItems attempt to display the entire commit message for each build
triggered by a commit. This is okay for most users as the message will
run out of space and be truncated. However, I among many others with
Hi-DPI displays have customized Drone's CSS to take up more monitor
space, which leads to some very ugly build names, as the RepoItem
displays the commit message and body.

This PR trims the title to just the first line of the commit message.