### PR TITLE
Add Ability to Filter Builds by Branch

### DIFF
--- a/src/views/Builds.vue
+++ b/src/views/Builds.vue
@@ -132,9 +132,6 @@ export default {
     },
     shrinkBuild(build) {
       return { ...build, message: null };
-    },
-    input(branch) {
-      this.defaultBranch = branch;
     }
   }
 };

--- a/src/views/Builds.vue
+++ b/src/views/Builds.vue
@@ -87,9 +87,8 @@ export default {
       return builds;
     },
     branches() {
-      const counts = {};
-      let branches = new Set();
-      branches.add("(All)");
+      const counts = {"(All)": 0};
+      let branches = new Set(["(All)"]);
       this.builds.forEach( build => {
         if (typeof counts[build.target] === 'undefined') {
           counts[build.target] = 0;
@@ -100,7 +99,13 @@ export default {
       branches = [... branches];
       // Sort branches by most builds but prefer master if it's in there
       branches = branches.sort((a, b) => {
-        if (b === "master") {
+        if (b === "(All)" && a === "master") {
+          return 1;
+        }
+        if (b === "master" && a === "(All)") {
+          return -1;
+        }
+        if (b === "master" || b === '(All)') {
           return 1;
         }
         return counts[b] - counts[a];


### PR DESCRIPTION
This PR is an initial pass at adding some filtering abilities to the builds list.

This keeps the same default functionality of the current build list by showing all recent builds, however adds the ability to filter that down further by branch.
A dropdown lists all the branches available to filter by, sorted by the frequency of builds (more builds → higher on the list), floating the `master` branch to the top of the list if it's present.

I'm very open to making changes to how this works, but it's something we're starting to use internally and seeing as though it's something our users have been asking for, I assume it's a feature others would like to see in Drone as well.

Thanks!