### PR TITLE
Force close of search box after item selection

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -95,6 +95,7 @@ export default {
     onItemSelect() {
       this.$refs.searchInput.$el.blur();
       this.clear();
+      this.close();
     },
     clear() {
       this.query = "";


### PR DESCRIPTION
In Firefox, for some reason selecting an item with the mouse would not
clear the search overlay. It appears that it would generally clear when
the blur function is called, but something appears to be different when
selected by mouse vs enter key.

This forces a call to `this.close()` to close the dialog without relying
only on the blur action.

Fixes #263