### PR TITLE
Don't open links in new tab

### DIFF
--- a/src/shared/components/build_event.js
+++ b/src/shared/components/build_event.js
@@ -51,7 +51,7 @@ export default class BuildEvent extends Component {
 						)}
 					</div>
 				</div>
-				<a href={link} target="_blank">
+				<a href={link}>
 					<LaunchIcon />
 				</a>
 			</div>


### PR DESCRIPTION
According to this [random guy](https://uxdesign.cc/linking-to-a-new-tab-vs-same-tab-f88b495d2187) on the internet there are only a few good excuses for opening a link in a new tab:

> The only time it is recommended that you open a link in a new tab is when opening in the same screen would interrupt a process (e.g. when a user is filling out a form or viewing a video).
> 
> Linking in the same tab or screen in these situations could cause the user to lose the work they’ve done or have to start over. Linking to a new tab in these cases can help the user find additional information without causing issues or forcing the user to start over. 

As far as I'm concerned, the build details isn't interrupting any work by the user when opening the PR link back into GitHub.