### PR TITLE
Disable font ligatures in build log

### DIFF
--- a/src/views/Build.vue
+++ b/src/views/Build.vue
@@ -736,6 +736,7 @@ $output-header-sticky-offset: 20px;
 .output-lines {
   width: 100%;
   line-height: 19px;
+  font-variant-ligatures: none;
 }
 
 .ol-pos,


### PR DESCRIPTION
Fixes #324

**Before:**
[![](https://user-images.githubusercontent.com/13909717/74612667-720e0900-50d5-11ea-9ae7-f5bc3559e2c1.png)](https://cloud.drone.io/geek1011/dictutil/64/7/6)

**After:**
![lig2](https://user-images.githubusercontent.com/13909717/74612666-71757280-50d5-11ea-9069-dee265b08add.png)

@bradrydzewski 
