### PR TITLE
Add Pulls and Pushes view to individual repo

### DIFF
--- a/src/components/RepoItemLabel.vue
+++ b/src/components/RepoItemLabel.vue
@@ -45,20 +45,16 @@ export default {
       }
     },
     hrefPR() {
-      return this.build && this.repo &&
-        `/link/${this.repo.slug}/tree/${this.build.ref}`;
+      return this.build && this.repo && `/link/${this.repo.slug}/tree/${this.build.ref}`;
     },
     hrefTag() {
-      return this.build && this.repo &&
-        `/link/${this.repo.slug}/tree/${this.build.ref}`;
+      return this.build && this.repo && `/link/${this.repo.slug}/tree/${this.build.ref}`;
     },
     hrefBranch() {
-      return this.build && this.repo &&
-        `/link/${this.repo.slug}/tree/refs/heads/${this.build.target}`;
+      return this.build && this.repo && `/link/${this.repo.slug}/tree/refs/heads/${this.build.target}`;
     },
     hrefCommit() {
-      return this.build && this.repo &&
-        `/link/${this.repo.slug}/commit/${this.build.after}`;
+      return this.build && this.repo && `/link/${this.repo.slug}/commit/${this.build.after}`;
     },
     branch() {
       return this.build.target;

--- a/src/components/SystemAlert.vue
+++ b/src/components/SystemAlert.vue
@@ -26,7 +26,7 @@ footer {
 }
 
 footer a {
-  background: rgba(255,255,255,0.15);
+  background: rgba(255, 255, 255, 0.15);
   border-radius: 3px;
   color: #ffffff;
   margin-left: 20px;

--- a/src/components/forms/BaseInput.vue
+++ b/src/components/forms/BaseInput.vue
@@ -26,7 +26,8 @@ input {
   background: #fff;
 }
 
-input[type="search"], input[type=text] {
+input[type="search"],
+input[type="text"] {
   appearance: none;
 }
 

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -12,6 +12,8 @@ import Repo from "../views/Repo.vue";
 import Settings from "../views/Settings.vue";
 import Search from "../views/Search.vue";
 import BuildsFeed from "../views/BuildsFeed.vue";
+import Pulls from "../views/Pulls.vue";
+import Pushes from "../views/Pushes.vue";
 
 export default new Router({
   mode: "history",
@@ -68,6 +70,16 @@ export default new Router({
               path: "",
               name: "builds",
               component: Builds
+            },
+            {
+              path: "pushes",
+              name: "pushes",
+              component: Pushes
+            },
+            {
+              path: "pulls",
+              name: "pulls",
+              component: Pulls
             },
             {
               path: "settings",

--- a/src/store.js
+++ b/src/store.js
@@ -492,7 +492,7 @@ export default new Vuex.Store({
         insertBuildCollection(state.builds[slug].data, slug, build);
       }
 
-      updateBuildsFeedByBuild(state, build)
+      updateBuildsFeedByBuild(state, build);
     },
 
     BUILDS_FEED_LOADING(state) {

--- a/src/views/Build.vue
+++ b/src/views/Build.vue
@@ -259,8 +259,7 @@ export default {
       return this.buildCollection.data;
     },
     link() {
-      return this.build && this.repo &&
-        `/link/${this.repo.slug}/tree/${this.build.ref}?sha=${this.build.after}`
+      return this.build && this.repo && `/link/${this.repo.slug}/tree/${this.build.ref}?sha=${this.build.after}`;
     },
     buildShowState() {
       if (this.buildCollection.lStatus === "error") return "loadingError";

--- a/src/views/Pulls.vue
+++ b/src/views/Pulls.vue
@@ -64,8 +64,10 @@ export default {
 
       for (let i = 0; i < buildCollections.length; ++i) {
         const data = buildCollections[i].data;
-        
-        if (data) builds.push(data);
+
+        if (data && data.event === "pull_request") {
+          builds.push(data);
+        }
       }
 
       builds.sort((a, b) => b.number - a.number);

--- a/src/views/Pushes.vue
+++ b/src/views/Pushes.vue
@@ -64,8 +64,11 @@ export default {
 
       for (let i = 0; i < buildCollections.length; ++i) {
         const data = buildCollections[i].data;
-        
-        if (data) builds.push(data);
+
+        if (data && data.event === "push") {
+          console.log(data.event);
+          builds.push(data);
+        }
       }
 
       builds.sort((a, b) => b.number - a.number);

--- a/src/views/Repo.vue
+++ b/src/views/Repo.vue
@@ -34,7 +34,7 @@
         <span>Activity Feed</span>
       </router-link>
     </nav>
-<!-- /:namespace/:name -->
+    
     <nav v-else-if="showTabs">
       <router-link :to="'/'+slug" :disabled="!repo.active">Activity Feed</router-link>
       <router-link :to="'/'+slug + '/pushes'" v-if="showSettings">Pushes</router-link>

--- a/src/views/Repo.vue
+++ b/src/views/Repo.vue
@@ -34,9 +34,11 @@
         <span>Activity Feed</span>
       </router-link>
     </nav>
-
+<!-- /:namespace/:name -->
     <nav v-else-if="showTabs">
       <router-link :to="'/'+slug" :disabled="!repo.active">Activity Feed</router-link>
+      <router-link :to="'/'+slug + '/pushes'" v-if="showSettings">Pushes</router-link>
+      <router-link :to="'/'+slug + '/pulls'" v-if="showSettings">Pulls</router-link>
       <router-link :to="'/'+slug + '/settings'" v-if="showSettings">Settings</router-link>
     </nav>
 
@@ -133,7 +135,7 @@ export default {
       return (this.repo && this.repo.permissions && this.repo.permissions.write) || (this.user && this.user.admin);
     },
     isAdmin() {
-      return (this.repo && this.repo.permissions && this.repo.permissions.admin);
+      return this.repo && this.repo.permissions && this.repo.permissions.admin;
     },
     build() {
       const collection = this.$store.state.builds[this.slug];


### PR DESCRIPTION
This PR adds a filtering of the Activity feed by pull requests and pushes to each individual repo view.

Some questions I wanted to clarify - 

1. There were existing lint errors, I cleaned up a few that I saw but there are still some lint errors, should I clean all of them up?
2. The readme calls out running tests, but I could not find any tests. Am I missing them?

Example:

![drone-ui](https://user-images.githubusercontent.com/16355906/76526666-e40b1100-643b-11ea-94bd-2e471fb189d3.gif)
