### PR TITLE
Fix cut-off letter in stage name

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -77,7 +77,7 @@ span {
   font-weight: 600;
   margin-left: 10px;
   font-size: 14px;
-  line-height: 18px;
+  line-height: 20px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/115237/79017801-7e14c500-7b72-11ea-8f7f-8175c9350732.png)

After:
![image](https://user-images.githubusercontent.com/115237/79017837-971d7600-7b72-11ea-9245-9d9e48801e84.png)

Notice the 'g' is cut-off because of `overflow: hidden` and not enough `line-height`, this fixes it.