### PR TITLE
Merge build logs instead of concatinate it

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -106,6 +106,18 @@ function insertBuildCollection(data, number, build) {
   Vue.set(data, build.number, createPresentCollection(build));
 }
 
+function mergeLogs(previousLogs, newLogs) {
+  let logs = [];
+
+  for (var log of previousLogs) {
+    logs[log.pos] = log;
+  }
+  for (var log of newLogs) {
+    logs[log.pos] = log;
+  }
+  return logs;
+}
+
 export default new Vuex.Store({
   state: {
     mediaType: window.innerWidth >= 980 ? "desktop" : window.innerWidth > 480 ? "tablet" : "mobile",
@@ -608,7 +620,7 @@ export default new Vuex.Store({
     LOG_WRITE(state, { lines }) {
       applySuccess(state.logs);
       escapeLogs(lines);
-      state.logs.data = state.logs.data.concat(lines);
+      state.logs.data = mergeLogs(state.logs.data, lines);
     },
 
     NOTIFICATION_ADD(state, notification) {


### PR DESCRIPTION
Sometimes server sent build log event since first line and drone-ui
append to the old build log. This approach make a user see a build since
first line again even it already shown. Fix it by merge a new logs to
the old logs by using field "pos" as a array index.