### PR TITLE
use pre-line replace pre-wrap

### DIFF
--- a/src/views/Build.vue
+++ b/src/views/Build.vue
@@ -789,7 +789,7 @@ $output-header-sticky-offset: 20px;
 
 .ol-html {
   word-break: break-word;
-  white-space: pre-wrap;
+  white-space: pre-line;
   padding-right: 15px;
 }
 


### PR DESCRIPTION
`pre-wrap` will keep all spaces that will cause text to exceed the log box like #309 .

`pre-line` includes `pre-wrap` but the sequences of whitespace will collapse into a single whitespace.

![](https://i.loli.net/2020/10/15/to1BmJjpSFQKLsw.png)

