### PR TITLE
Add a 'New Build' button and modal on builds page.

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,8 +1,9 @@
 export {
   cancelBuild,
+  createBuild,
   fetchBuild,
   fetchBuilds,
-  createBuild,
+  retryBuild,
   createDeployment,
   approveBuild,
   declineBuild,

--- a/src/components/forms/NewBuildForm.vue
+++ b/src/components/forms/NewBuildForm.vue
@@ -1,0 +1,148 @@
+<template>
+  <BaseForm @submit.native.prevent="handleSubmit" class="form">
+    <header>
+      <h2 class="title">
+        Start a New Build
+      </h2>
+    </header>
+    <div class="control-group">
+      <div class="control-label">
+        <label>Branch (required)</label>
+      </div>
+      <div class="controls">
+        <BaseInput
+          v-model="branch"
+          name="branch"
+          autocomplete="off"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          placeholder="main"
+          type="text"
+        />
+      </div>
+    </div>
+    <div class="control-group">
+      <div class="control-label">
+        <label>Commit Hash</label>
+      </div>
+      <div class="controls">
+        <BaseInput
+          v-model="commitHash"
+          name="commitHash"
+          autocomplete="off"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          placeholder=""
+          type="text"
+        />
+      </div>
+    </div>
+    <div class="control-actions">
+      <Button type="submit" size="l" theme="primary">Start New Build</Button>
+      <Button type="button" size="l" outline @click.native="handleCancel">Cancel</Button>
+    </div>
+  </BaseForm>
+</template>
+
+<script>
+import Button from "@/components/buttons/Button.vue";
+import BaseInput from "@/components/forms/BaseInput";
+import BaseForm from "@/components/forms/BaseForm";
+export default {
+  name: "NewBuildForm",
+  components: {
+    Button,
+    BaseInput,
+    BaseForm
+  },
+  data() {
+    return {
+      branch: "",
+      commitHash: "",
+    }
+  },
+  props: {
+    targets: {type: Array, default() { return [] }}
+  },
+  methods: {
+    handleSubmit(e) {
+      this.$emit("submit", {branch: this.branch, commitHash: this.commitHash});
+    },
+    handleCancel(e) {
+      this.$emit("cancel");
+    },
+  }
+};
+</script>
+
+<style scoped lang="scss">
+.form {
+  min-width: 641px;
+  .base-input {
+    width: 100%;
+  }
+  header {
+    height: 50px;
+    line-height: 50px;
+    border-bottom: 1px solid rgba(30,55,90,.05);
+    padding: 0 15px;
+    display: flex;
+    align-items: center;
+    .title {
+      font-size: 16px;
+      font-weight: 600;
+    }
+  }
+  .control-group,
+  .control-actions,
+  .header {
+    padding: 11px 15px;
+  }
+  .control-group {
+    align-items: baseline;
+    .control-label {
+      flex-basis: 0;
+      flex-grow: 1;
+      flex-shrink: 0;
+      text-align: right;
+      margin-right: 1.5rem;
+    }
+    .controls {
+      flex-basis: 0;
+      flex-grow: 5;
+      flex-shrink: 1;
+    }
+  }
+  .control-actions {
+    .button + .button {
+      margin-left: 1rem;
+    }
+  }
+  .param-list {
+    &:not(:empty) {
+      margin-bottom: 16px;
+    }
+  }
+  .param-list-item {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    padding: 2px 0;
+    code {
+      font-family: monospace;
+    }
+  }
+  .param-list-form {
+    display: flex;
+    flex-wrap: nowrap;
+    * + * {
+      margin-left: 0.5rem;
+    }
+    * {
+      flex-shrink: 1;
+    }
+  }
+}
+</style>

--- a/src/views/Build.vue
+++ b/src/views/Build.vue
@@ -366,8 +366,7 @@ export default {
     },
     handleRestart: function() {
       const { namespace, name, build } = this.$route.params;
-
-      this.$store.dispatch("createBuild", { namespace, name, build }).then(data => {
+      this.$store.dispatch("retryBuild", { namespace, name, build }).then(data => {
         this.$router.push(`/${namespace}/${name}/${data.build.number}`);
       });
     },

--- a/src/views/Builds.vue
+++ b/src/views/Builds.vue
@@ -8,6 +8,17 @@
         <div class="empty-message">Your Build List is Empty.</div>
       </Alert>
 
+      <portal to="secondary-page-header-actions">
+        <div class="header-actions">
+          <Button theme="primary"
+                  class="button-new-build"
+                  @click.native="openNewBuildModal">
+            <span>New Build</span>
+            <IconPlay/>
+          </Button>
+        </div>
+      </portal>
+
       <router-link
         class="build"
         v-for="build in builds"
@@ -21,6 +32,10 @@
                   :linkRepo="repo"/>
       </router-link>
 
+      <Modal className="new-build-modal" v-if="showNewBuildModal">
+        <NewBuildForm @submit="handleNewBuild" @cancel="closeNewBuildModal" />
+      </Modal>
+
       <MoreButton v-if="showHasMore" @click.native="showMore">Show more</MoreButton>
     </template>
 
@@ -32,9 +47,14 @@
 import Alert from "@/components/Alert.vue";
 import RepoItem from "@/components/RepoItem.vue";
 import Loading from "@/components/Loading.vue";
+import Button from "@/components/buttons/Button.vue";
+import Modal from "@/components/Modal.vue";
 import MoreButton from "@/components/buttons/MoreButton.vue";
 import AlertError from "@/components/AlertError.vue";
 import IconDroneSleep from "@/components/icons/IconDroneSleep";
+import IconPlay from "@/components/icons/IconPlay";
+import NewBuildForm from "@/components/forms/NewBuildForm.vue";
+
 
 export default {
   name: "Builds",
@@ -44,7 +64,16 @@ export default {
     Loading,
     AlertError,
     MoreButton,
-    IconDroneSleep
+    Button,
+    IconDroneSleep,
+    IconPlay,
+    NewBuildForm,
+    Modal,
+  },
+  data() {
+    return {
+      showNewBuildModal: false,
+    };
   },
   computed: {
     slug() {
@@ -89,6 +118,19 @@ export default {
     }
   },
   methods: {
+    openNewBuildModal: function() {
+      this.showNewBuildModal = true;
+    },
+    closeNewBuildModal: function() {
+      this.showNewBuildModal = false;
+    },
+    handleNewBuild: function(newBuildParams) {
+      const { namespace, name, build } = this.$route.params;
+      this.$store.dispatch("createBuild", { namespace, name, build, ...newBuildParams }).then(data => {
+        this.showNewBuildModal = false;
+        this.$router.push(`/${namespace}/${name}/${data.build.number}`);
+      });
+    },
     showMore() {
       this.$store.dispatch("fetchBuilds", { ...this.$route.params, page: this.collection.page + 1 });
     },
@@ -147,6 +189,19 @@ export default {
 
   @include mobile {
     margin-left: 7px;
+  }
+}
+
+.header-actions {
+  margin: -5px;
+  align-self: flex-start;
+
+  @include mobile {
+    margin-top: 10px;
+  }
+
+  .button {
+    margin: 5px;
   }
 }
 </style>


### PR DESCRIPTION
Many other CI systems -- Jenkins, Buildkite, Concourse, etc. -- include a way to kick off an arbitrary build from the UI by just providing a branch (and optionally a commit hash). This is helpful for multiple reasons, and is a fairly low lift add.

![drone](https://user-images.githubusercontent.com/448732/96641466-c0257d00-12f2-11eb-9e0f-47ee11a240fe.gif)

One thing I didn't do -- primarily just lacking time right now -- is add in a way to populate environment variables specific to the run. Would be easy enough to add another form field and then add them as querystring params.

Resolves https://github.com/drone/drone-ui/issues/298.