### PR TITLE
Enable collapsing/expanding of stages

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -1,15 +1,17 @@
 <template>
-  <section :class="{ stage: true, 'has-steps': hasSteps, 'has-content': hasContent}">
-    <header>
-      <Status :status="stage.status"/>
-      <span :title="stage.name">{{ stage.name }}</span>
-      <time-elapsed v-if="stage.started" :started="stage.started" :stopped="stage.stopped">
-        <Hint position="top" align="right" showOn="hover">Full stage duration</Hint>
-      </time-elapsed>
-      <IconArrowDropdown v-if="hasSteps" direction="down" class="arrow-dropdown"/>
-    </header>
+  <section :class="{ stage: true, 'has-steps': hasSteps, 'has-content': hasContent, expanded: isExpanded}">
+    <component :is="isSelected && hasContent ? 'button' : 'div'" @click="emitClick" :aria-label="stageButtonLabel">
+      <header>
+        <Status :status="stage.status"/>
+        <span :title="stage.name" class="stage-title">{{ stage.name }}</span>
+        <time-elapsed v-if="stage.started" :started="stage.started" :stopped="stage.stopped">
+          <Hint position="top" align="right" showOn="hover">Full stage duration</Hint>
+        </time-elapsed>
+        <IconArrowDropdown v-if="hasSteps" direction="down" class="arrow-dropdown"/>
+      </header>
+    </component>
 
-    <div class="content">
+    <div v-if="isSelected && hasContent" class="content">
       <slot></slot>
     </div>
   </section>
@@ -24,7 +26,9 @@ import Hint from "./Hint";
 export default {
   name: "Stage",
   props: {
-    stage: { type: Object, required: true }
+    stage: { type: Object, required: true },
+    isSelected: { type: Boolean, required: false, default: false },
+    isExpanded: { type: Boolean, required: false, default: false }
   },
   components: {
     Hint,
@@ -38,6 +42,16 @@ export default {
     },
     hasContent() {
       return !!this.$slots.default;
+    },
+    stageButtonLabel() {
+      if (!this.isSelected) return null
+
+      return this.isExpanded ? "Collapse this stage" : "Expand this stage"
+    }
+  },
+  methods: {
+    emitClick() {
+      this.isSelected && this.$emit("click");
     }
   }
 };
@@ -54,7 +68,51 @@ export default {
   box-sizing: border-box;
   user-select: none;
 
-  &.has-content header {
+  &:hover,
+  &:focus {
+    &.has-steps {
+      .stage-title {
+        padding-right: 5px;
+      }
+
+      .time-elapsed {
+        display: none;
+      }
+
+      .arrow-dropdown {
+        display: inline-block;
+      }
+    }
+
+    &.expanded {
+      .arrow-dropdown {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  button {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &:hover,
+    &:focus {
+      outline: none;
+
+      header {
+        background-color: rgba($color-text, 0.02);
+      }
+    }
+  }
+
+  &.has-content.expanded header {
     border-bottom: solid 1px rgba($color-text, 0.1);
   }
 }

--- a/src/views/Build.vue
+++ b/src/views/Build.vue
@@ -57,10 +57,11 @@
 
           <!--
             If the stage is selected it is expanded, and
-            all steps are displayed.
+            all steps are displayed. Clicking on the stage
+            header will collapse/expand the section.
           -->
-          <Stage v-else :stage="_stage">
-            <div v-for="(_step) in _stage.steps" :key="_step.id" class="step-container">
+          <Stage v-else :stage="_stage" :is-selected="true" :is-expanded="isStageExpanded" @click="toggleStage">
+            <div v-show="isStageExpanded" v-for="(_step) in _stage.steps" :key="_step.id" class="step-container" :aria-hidden="!isStageExpanded">
               <Step v-if="_step === step"
                     selected
                     :name="_step.name"
@@ -228,7 +229,8 @@ export default {
       follow: false,
       logStep: 250,
       logLimit: 250,
-      showToTop: false
+      showToTop: false,
+      isStageExpanded: true
     };
   },
   mounted() {
@@ -447,6 +449,9 @@ export default {
       } else if (step.started) {
         this.$store.dispatch("streamLogs", this.$route.params);
       }
+    },
+    toggleStage() {
+      this.isStageExpanded = !this.isStageExpanded;
     }
   },
   watch: {
@@ -467,6 +472,7 @@ export default {
       // is running, dispatch a request to stream the logs.
       if (!oldStep || oldStep.id !== newStep.id) {
         this.$store.commit("LOG_CLEAR");
+        this.isStageExpanded = true;
 
         this.follow = false;
         this.logLimit = 250;
@@ -828,6 +834,10 @@ $output-header-sticky-offset: 20px;
       }
 
       &.has-steps {
+        .stage-title {
+          padding-right: 5px;
+        }
+
         time {
           display: none;
         }


### PR DESCRIPTION
This PR introduces the ability to collapse/expand stages. IMHO it makes sense to enable users to do this in case the user has a pipeline with a lot of steps which makes it then "more work" to scroll between different pipelines as he needs to first scroll through all those steps. When selecting the pipeline, it is of course always expanded. Same when switching between pipelines.

For accessibility, I've implemented it as a `button`. I did it directly in the `Stage` component and I think it would make sense to move there also the `router-link`. This would save some code in the `Build` component and would make `Stage` really encapsulated. This is why I created the styles for the button in the `Stage` component and didn't reuse the ones in `Build`. Let me pls know what you think about this idea @bradrydzewski 🙂 If you'd like this approach I could move it in there already in this PR or in a separate one - your call 😉 

When using the `button`, it created one small change in behaviour though. Since `button` is getting outline by default when clicking on it, I disabled it via CSS. This breaks the behaviour of the other pipelines though - since they are links, you do not get the outline when clicking but you get it when tabbing. This is now not working for the selected pipeline.

As one last tiny change, I added small padding of 5px to the title of the pipeline on hover/focus. This is to let the chevron icon on the right breath a little since previously the text would go all the way to that icon (the three dots when the text is truncated).