### PR TITLE
Add more details about the project visibility setting

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -36,8 +36,20 @@
                             name="visibility"
                             :options="{ public: 'Public', private: 'Private', internal: 'Internal'}"/>
         </div>
-        <!-- todo href for help -->
-        <Help title="Project visibility">Provides the repository visibility level.</Help>
+        <Help title="Project visibility">
+          <p class="help-p">
+            <a href="https://docs.drone.io/setting/#public" target="_blank" class="link">Public</a>
+            - If Enabled, visible by anyone.
+          </p>
+          <p class="help-p">
+            <a href="https://docs.drone.io/setting/#private" target="_blank" class="link">Private</a>
+            - If Enabled, visible by anyone with access.
+          </p>
+          <p class="help-p">
+            <a href="https://docs.drone.io/setting/#internal" target="_blank" class="link">Internal</a>
+            - If Enabled, visible by any authenticated user.
+          </p>
+        </Help>
       </div>
 
       <div v-if="isRoot" class="control-group">


### PR DESCRIPTION
Update the project visibility information tooltip for more detailed information.

From this:
<img width="268" alt="image" src="https://user-images.githubusercontent.com/23703318/108249321-388f3400-7155-11eb-9c84-92802eb330a1.png">

To this:
<img width="274" alt="image" src="https://user-images.githubusercontent.com/23703318/108250103-219d1180-7156-11eb-8b2f-58933ee68e35.png">

See https://github.com/drone/docs/pull/441 for link to documentation.