### PR TITLE
feat(Builds): Add filter by event

### DIFF
--- a/src/pages/builds/builds.module.scss
+++ b/src/pages/builds/builds.module.scss
@@ -2,7 +2,7 @@
 @import "styles/mixins";
 
 .wrapper {
-  padding-top: 54px;
+  padding-top: 0px;
   max-width: 1700px;
   margin: 0px auto;
   @include sm-down {
@@ -42,5 +42,42 @@
     color: #0092e4;
     box-shadow: none;
     text-transform: capitalize;
+  }
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-top: 5px;
+  & > * + * {
+    margin-left: 24px;
+  }
+
+  @include md-down {
+      flex: 1 1 100%;
+      padding: 10px 0px;
+      & > * + * {
+        margin-left: 0;
+        margin-top: 12px;
+      }
+      flex-flow: column;
+      justify-content: center;
+      align-items: flex-end;
+  }
+}
+
+
+
+.select {
+  padding: 8px 12px 8px 34px;
+  font-size: 14px;
+
+  @include md-down {
+    padding: 0;
+    width: 100%;
+    input {
+      width: 100% !important;
+    }
   }
 }


### PR DESCRIPTION
Allows filtering repo builds by push, cron or PR

The pagination doesn't adapt to the new type (you get a list of less than 50 items), you may have to click a few times on show more to get a full 50 items list (depending on your build event type distribution). However, I really think that this is a really useful feature. There is currently no way to differentiate a cron from a normal build (or to get the average duration of all crons)

Here's what it looks like:

Default filter (all):
![image](https://user-images.githubusercontent.com/29210090/119919555-b030e400-bf38-11eb-9c53-4904db1502b6.png)

With cron filter:
![image](https://user-images.githubusercontent.com/29210090/119919520-9d1e1400-bf38-11eb-8929-0f20adcd55f5.png)



