### PR TITLE
Meta Description: Replace create-react-app text with Drone text

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Drone is a self-service Continuous Integration platform for busy development teams."
     />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
I was tired of seeing "Web site created using create-react-app" when linking to builds etc.