### PR TITLE
allow ~ in project name

### DIFF
--- a/src/hooks/swr/builds.js
+++ b/src/hooks/swr/builds.js
@@ -52,8 +52,8 @@ const useBuild = ({ namespace, name, build }) => useSWRBase(`/api/repos/${namesp
 const streamDependants = [
   { regex: new RegExp(/^\/$/), page: 'Home' },
   { regex: new RegExp(/^\/builds-feed$/), page: 'BuildsFeed' },
-  { regex: new RegExp(/^\/[a-zA-Z0-9-_.]+?\/[a-zA-Z0-9-_.]+?$/), page: 'Builds' },
-  { regex: new RegExp(/^\/[a-zA-Z0-9-_.]+?\/[a-zA-Z0-9-_.]+?\/[0-9]+?(\/[0-9]+?\/[0-9]+?)?$/), page: 'Build' },
+  { regex: new RegExp(/^\/[a-zA-Z0-9-_.~]+?\/[a-zA-Z0-9-_.]+?$/), page: 'Builds' },
+  { regex: new RegExp(/^\/[a-zA-Z0-9-_.~]+?\/[a-zA-Z0-9-_.]+?\/[0-9]+?(\/[0-9]+?\/[0-9]+?)?$/), page: 'Build' },
 ];
 
 // latest repos updater


### PR DESCRIPTION
Bitbucket server allow users to create private repositories. The path looks like this: gitserver.company.com/~muffl0n/drone-test.git

This PR adds ~ as a allowed char in the project name