### PR TITLE
add tooltip to long build step names

### DIFF
--- a/src/components/pages/build/log-view/stage-nav/stage-nav.jsx
+++ b/src/components/pages/build/log-view/stage-nav/stage-nav.jsx
@@ -149,6 +149,7 @@ const StageDefault = (props) => {
                 return (match || (stageNumber == stageInPath && !stepIdx));
               }}
               to={`/${namespace}/${name}/${build}/${stageNumber}/${stepIndex + 1}`}
+              title={stepName}
               exact
               onClick={onStepClick}
             >


### PR DESCRIPTION
- Adds a simple tooltip to the build step button incase step title is too long for UI