### PR TITLE
Remove svg animation

### DIFF
--- a/src/components/shared/status/status.module.scss
+++ b/src/components/shared/status/status.module.scss
@@ -50,14 +50,6 @@
     background: #09c270;
   }
 
-  &-running,
-  &-pending,
-  &-blocked,
-  &-waiting_on_dependencies {
-    svg {
-      animation: spin 2s linear infinite;
-    }
-  }
   &-pending,
   &-blocked,
   &-waiting_on_dependencies {


### PR DESCRIPTION
This removes the infinite spin animation on the running, pending blocked, and waiting status SVGs (for reference, the SVGs are at https://github.com/drone/drone-ui/tree/main/src/svg/status).  

This should fix #315 and likely #363.