### PR TITLE
disable user-select on console line numbers and times

### DIFF
--- a/src/components/shared/console/console.module.scss
+++ b/src/components/shared/console/console.module.scss
@@ -110,6 +110,7 @@
 
 .line-number {
   display: table-cell;
+  user-select: none;
   padding-right: 28px;
   text-align: end;
   white-space: nowrap;
@@ -129,6 +130,7 @@
 
 .line-time {
   display: table-cell;
+  user-select: none;
   padding-left: 28px;
   text-align: end;
   white-space: nowrap;


### PR DESCRIPTION
This trivial patch goes some way towards addressing a [problem I reported on the lists a while ago](https://discourse.drone.io/t/9429).

Our goal is as follows.  We would like to select and copy text from the console UI without superfluous noise.  The text in the user's clipboard buffer must closely match what is displayed in the browser.  (We can happily live without colours or other stuff that cannot be represented in plain text.)

There are at least two smaller problems here:
1. We must avoid copying the leading line number and trailing timestamp (or time offset).
2. We must avoid superfluous blank lines between content lines.

This patch seems to fix (1) but does not fix (2).

Before:

![before](https://user-images.githubusercontent.com/194389/138077875-6e2a3e5c-3c58-4ec8-b0f0-fbd7259e2b0b.png)

After:

![after](https://user-images.githubusercontent.com/194389/138077914-b572cd5e-54e3-4ebe-a239-1657415d66c0.png)

On Firefox, copying the selected text produces the following on paste:

```
 _____ 

< moo >

 ----- 
```

As far as I can tell, this probably has something to do with the trailing newline in the span content (because `white-space: pre-wrap`?):

```
<code class="ansi-hook console_output__2qZpe"><div class="console_line__1ir27"><span class="console_line-number__3zolU">1</span><span class="loc-html console_line-content__3xTWR">+ cowsay moo
</span><span class="console_line-time__oQvWj">0s</span></div><div class="console_line__1ir27"><span class="console_line-number__3zolU">2</span><span class="loc-html console_line-content__3xTWR"> _____ 
</span><span class="console_line-time__oQvWj">0s</span></div><div class="console_line__1ir27"><span class="console_line-number__3zolU">3</span><span class="loc-html console_line-content__3xTWR">&lt; moo &gt;
</span><span class="console_line-time__oQvWj">0s</span></div><div class="console_line__1ir27"><span class="console_line-number__3zolU">4</span><span class="loc-html console_line-content__3xTWR"> ----- 
</span><span class="console_line-time__oQvWj">0s</span></div><div class="console_line__1ir27"><span class="console_line-number__3zolU">5</span><span class="loc-html console_line-content__3xTWR">        \   ^__^
</span><span class="console_line-time__oQvWj">0s</span></div><div class="console_line__1ir27"><span class="console_line-number__3zolU">6</span><span class="loc-html console_line-content__3xTWR">         \  (oo)\_______
</span><span class="console_line-time__oQvWj">0s</span></div><div class="console_line__1ir27"><span class="console_line-number__3zolU">7</span><span class="loc-html console_line-content__3xTWR">            (__)\       )\/\
</span><span class="console_line-time__oQvWj">0s</span></div><div class="console_line__1ir27"><span class="console_line-number__3zolU">8</span><span class="loc-html console_line-content__3xTWR">                ||----w |
</span><span class="console_line-time__oQvWj">0s</span></div><div class="console_line__1ir27"><span class="console_line-number__3zolU">9</span><span class="loc-html console_line-content__3xTWR">                ||     ||
</span><span class="console_line-time__oQvWj">0s</span></div><div></div></code>
```

I don't know anything about web stuff.  This problem has caused quite a bit of consternation, though, so I thought I'd at least try to get the ball rolling in the hope that you can see an easy way forward.  Please feel free to do whatever you like with this patch.