### PR TITLE
remove local storage of build tab

### DIFF
--- a/src/pages/build/build.jsx
+++ b/src/pages/build/build.jsx
@@ -75,7 +75,7 @@ export default function Build({ user, userIsAdminOrHasWritePerm }) {
     data, mutate, isError, isLoading,
   } = useBuild({ namespace, name, build });
   const [state, setState] = useState(RESOLVED);
-  const [view, setView] = useLocalStorage('buildPageView', LOGS_VIEW);
+  const [view, setView] = useState(LOGS_VIEW);
 
   const [isModalShowing, toggleModal] = useModal();
 


### PR DESCRIPTION
Removing local storage of build tab to fix bug around the upcoming card tab only sometimes being present