### PR TITLE
Fix cut-off letter in stage name

### DIFF
--- a/src/components/pages/build/log-view/stage-nav/stage-nav.module.scss
+++ b/src/components/pages/build/log-view/stage-nav/stage-nav.module.scss
@@ -195,7 +195,7 @@
     position: relative;
     z-index: 0;
     font-size: 13px;
-    line-height: 1;
+    line-height: 15px;
     color: #22222a;
     &::before {
       position: absolute;


### PR DESCRIPTION
This prevents cut-off letters like `g` in the stage name. Similar to https://github.com/drone/drone-ui/pull/330, but for v2 this time.

Before:

<img width="291" alt="image" src="https://user-images.githubusercontent.com/115237/166833636-5e221ca2-fdf3-4da2-865a-72fc9736827f.png">

After:

<img width="292" alt="image" src="https://user-images.githubusercontent.com/115237/166833735-4131975b-fcce-4c85-bb1d-746f858608ce.png">