### PR TITLE
Fix minor grammar error in repository settings

### DIFF
--- a/src/pages/settings/general/general.jsx
+++ b/src/pages/settings/general/general.jsx
@@ -232,7 +232,7 @@ export default function General({ user, repo }) {
               <li className={cx('visibility-card-wrapper')}>
                 <div className={cx('visibility-card')}>
                   <h4>Internal</h4>
-                  <p>Internal repositories are only accessible to authenticated user.</p>
+                  <p>Internal repositories are only accessible to authenticated users.</p>
                 </div>
                 <Field.Radio
                   name="internal"


### PR DESCRIPTION
Change 

> Internal repositories are only accessible to authenticated user.

to

> Internal repositories are only accessible to authenticated users.