### PR TITLE
fix: expand adaptive card to full width of container

### DIFF
--- a/src/components/pages/build/cards-view/card.jsx
+++ b/src/components/pages/build/cards-view/card.jsx
@@ -53,7 +53,7 @@ const Card = ({
   }
   return (
     <li className={cx('card')}>
-      <AdaptiveCard payload={adaptiveCard} />
+      <AdaptiveCard payload={adaptiveCard} style={{ width: '100%' }} />
     </li>
   );
 };


### PR DESCRIPTION
I developed a drone plugin recently [that shows junit test report summary in the cards view](https://github.com/rohit-gohri/drone-junit/). Noticed that the card doesn't expand to take full width of container. So adding this small fix to make the card expand to 100% width.


#### Before
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/31949290/222293289-c538010e-1f2f-4c87-a38d-fcddcb5c801e.png">


#### After
<img width="891" alt="image" src="https://user-images.githubusercontent.com/31949290/222293532-6e8894c6-bebf-43f2-b72b-481a89875ac7.png">


### References
The adaptive cards library doesn't have a class name option but only a style prop option so did not use scss class to apply this - https://github.com/microsoft/AdaptiveCards/blob/45bd09ddac089832f1ca545788a622bbf9a16bf8/source/nodejs/adaptivecards-react/src/adaptive-card.tsx#L22
