### PR TITLE
Prepopulate the new-build-form with query params

### DIFF
--- a/src/components/pages/repo/new-build-form/new-build-form.jsx
+++ b/src/components/pages/repo/new-build-form/new-build-form.jsx
@@ -11,11 +11,17 @@ import css from './new-build-form.module.scss';
 
 const cx = classNames.bind(css);
 
-const NewBuildForm = ({ handleSubmit, handleCancel }) => {
+const NewBuildForm = ({
+  handleSubmit,
+  handleCancel,
+  target,
+  commit,
+  parameters
+}) => {
   const [state, setState] = useState({
-    target: '',
-    commit: '',
-    parameters: [],
+    target,
+    commit,
+    parameters,
   });
   const [parameterState, setParameterState] = useState({
     key: '',
@@ -107,9 +113,24 @@ const NewBuildForm = ({ handleSubmit, handleCancel }) => {
   );
 };
 
+NewBuildForm.defaultProps = {
+  target: "",
+  commit: "",
+  parameters: [],
+};
+
 NewBuildForm.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   handleCancel: PropTypes.func.isRequired,
+  target: PropTypes.string,
+  commit: PropTypes.string,
+  parameters: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string,
+      value: PropTypes.string,
+      id: PropTypes.string,
+    })
+  ),
 };
 
 export default NewBuildForm;

--- a/src/components/shared/modal/modal.jsx
+++ b/src/components/shared/modal/modal.jsx
@@ -10,8 +10,8 @@ import styles from './modal.module.scss';
 
 const cx = classNames.bind(styles);
 
-export const useModal = () => {
-  const [isShowing, setIsShowing] = useState(false);
+export const useModal = (isShowingInit = false) => {
+  const [isShowing, setIsShowing] = useState(isShowingInit);
   const toggle = () => setIsShowing(!isShowing);
   return [isShowing, toggle];
 };

--- a/src/pages/repo/repo.jsx
+++ b/src/pages/repo/repo.jsx
@@ -4,7 +4,7 @@ import React, {
   useCallback, useMemo, useContext,
 } from 'react';
 import {
-  Route, Switch, NavLink, useRouteMatch,
+  Route, Switch, NavLink, useRouteMatch, useLocation,
 } from 'react-router-dom';
 
 import { VISIBILITY_LEVELS } from '_constants';
@@ -62,7 +62,20 @@ const Repo = ({ user }) => {
   } = params;
   const [context] = useContext(AppContext);
   const { isRepoNavDisabled } = context;
-  const [isModalShowing, toggleModal] = useModal();
+  const { search } = useLocation();
+  const queryParams = new URLSearchParams(search);
+  let target = '';
+  let commit = '';
+  let parameters = [];
+  try {
+    target = queryParams.get('target') || '';
+    commit = queryParams.get('commit') || '';
+    parameters = queryParams.get('parameters') ? JSON.parse(queryParams.get('parameters')) : [];
+  } catch (e) {
+    console.warn('Invalid query parameters', e)
+  }
+  // If there is a target url param, show the new build modal on load
+  const [isModalShowing, toggleModal] = useModal(!!queryParams.get('target'));
 
   const { data: repo, isLoading: isRepoDataLoading, isError } = useRepo({ namespace, name });
 
@@ -202,7 +215,7 @@ const Repo = ({ user }) => {
             isShowing={isModalShowing}
             hide={toggleModal}
           >
-            <NewBuildForm handleSubmit={handleNewBuildSubmit} handleCancel={toggleModal} />
+            <NewBuildForm handleSubmit={handleNewBuildSubmit} handleCancel={toggleModal} target={target} commit={commit} parameters={parameters} />
           </Modal>
         </>
       </Route>


### PR DESCRIPTION
Currently manual drone promotions have be done by going into a drone build, clicking the kebab menu and clicking Promote.

Then the user has to fill out all of the fields necessary to promote their build. This is pretty user error prone. 

We do not want to automate this process completely for the time being (which we can currently already do via cli), we still want a user to have to manually trigger this drone promote when they are ready.

This PR will allow us to generate a drone url such as `/:namespace/:name/:build?target=production&commit=1234&parameters=[{"id":"1","key":"IMAGE_TAG","value":"1234"},{"id":"2","key":"ACTION","value":"deploy"}]` . We can then give this generated link to our developers via slack (or anywher else) so they can easily click a link and click Promote without having to manually type out the parameter fields. 