### PR TITLE
feat: Show the value in the promotion dialog

### DIFF
--- a/src/pages/build/deployment-form/deployment-form.jsx
+++ b/src/pages/build/deployment-form/deployment-form.jsx
@@ -97,9 +97,10 @@ const DeploymentForm = ({ handleSubmit, handleCancel }) => {
       <FormSection title="Parameters" className={cx('deployment-form-row')}>
         {state.parameters.length ? (
           <div className={cx('deployment-form-parameters-list')}>
-            {state.parameters.map(({ key, id }) => (
+            {state.parameters.map(({ key, value, id }) => (
               <div className={cx('deployment-form-parameters')} key={id}>
                 <span type="text" placeholder="key">{key}</span>
+                <span type="text" placeholder="value">[{value}]</span>
                 <Button type="button" onClick={handleRemoveParameter(id)}>Remove</Button>
               </div>
             ))}


### PR DESCRIPTION
This PR shows the value of the parameters in the prompt when promoting. It is confusing when you promote through prepopulating the config #432, but don't see the values of the parameters.